### PR TITLE
Changed PACSSource to use a single DicomClient for all orders

### DIFF
--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -216,6 +216,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                     #endregion
                     //go and get them
                     #region Retrieval
+                    DicomClient client = new DicomClient();
 
                     var transferStopwatch = new Stopwatch();
                         //start building request to fill orders 
@@ -274,7 +275,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                                     transferStopwatch.Elapsed));
                              //do not use requestSender.ThrottleRequest(cMoveRequest, cancellationToken);
                             //TODO is there any need to throtttle this request given its lifetime
-                            DicomClient client = new DicomClient();
+                            
                             requestSender.ThrottleRequest(cMoveRequest, client, cancellationToken);
                             transferTimeOutTimer.Reset();
                             while (!pickerFilled && !hasTransferTimedOut)
@@ -284,12 +285,13 @@ namespace Rdmp.Dicom.Cache.Pipeline
                                 transferTimerPollingPeriods++;
                             }
                             transferTimeOutTimer.Stop();
-                            client.Release();
                             listener.OnProgress(this,
                                 new ProgressEventArgs(CMoveRequestToString(cMoveRequest),
                                     new ProgressMeasurement(picker.Filled(), ProgressType.Records, picker.Total()),
                                     transferStopwatch.Elapsed));
                         }
+
+                        client.Release();
 
                         #endregion
                     }


### PR DESCRIPTION
Looking at the logs from last test it looks like we are getting images ok and then seeing `Released Association ...` which I assume comes from `client.Release()`.  The next entry is 15 minutes later and simultaneously `Progress: 2 Records of 2` (from PACSSource) and `ConnectionClosed` (from CachingSCP).  So I am thinking that `client.Release()` is blocking for 15 mins.

I'm not sure why we are creating a separate client for every study anyway.  This PR is to change to a single client for all the studies/C-Move.

It probably won't solve our problem but hopefully will shed light on it.

Other issues:
- DicomClient might only be allowed 10,000 image transfers
- DicomClient is listed as deprecated