### PR TITLE
Allow the PACS to send us lossy-compressed images if it has them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow the PACS to send us lossy compressed versions if it wants, otherwise we won't be able to receive anything it has in that format
+
 ### Added
 
 - Added new cache source `ProcessBasedCacheSource` that calls out to a remote process

--- a/Rdmp.Dicom/Cache/Pipeline/CachingSCP.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CachingSCP.cs
@@ -27,6 +27,12 @@ namespace Rdmp.Dicom.Cache.Pipeline
             DicomTransferSyntax.JPEGProcess14SV1,
             DicomTransferSyntax.JPEGProcess14,
             DicomTransferSyntax.RLELossless,
+
+            // Lossy - if that's all the PACS has, that's all it can give us
+            DicomTransferSyntax.JPEGLSNearLossless,
+            DicomTransferSyntax.JPEG2000Lossy,
+            DicomTransferSyntax.JPEGProcess1,
+            DicomTransferSyntax.JPEGProcess2_4,
 			
             // Uncompressed
             DicomTransferSyntax.ExplicitVRLittleEndian,

--- a/Rdmp.Dicom/Cache/Pipeline/CachingSCP.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CachingSCP.cs
@@ -33,6 +33,17 @@ namespace Rdmp.Dicom.Cache.Pipeline
             DicomTransferSyntax.JPEG2000Lossy,
             DicomTransferSyntax.JPEGProcess1,
             DicomTransferSyntax.JPEGProcess2_4,
+
+            // Also allow video files, just in case
+            DicomTransferSyntax.HEVCH265Main10ProfileLevel51,
+            DicomTransferSyntax.HEVCH265MainProfileLevel51,
+            DicomTransferSyntax.MPEG2,
+            DicomTransferSyntax.MPEG2MainProfileHighLevel,
+            DicomTransferSyntax.MPEG4AVCH264BDCompatibleHighProfileLevel41,
+            DicomTransferSyntax.MPEG4AVCH264HighProfileLevel41,
+            DicomTransferSyntax.MPEG4AVCH264HighProfileLevel42For2DVideo,
+            DicomTransferSyntax.MPEG4AVCH264HighProfileLevel42For3DVideo,
+            DicomTransferSyntax.MPEG4AVCH264StereoHighProfileLevel42,
 			
             // Uncompressed
             DicomTransferSyntax.ExplicitVRLittleEndian,


### PR DESCRIPTION
DICOM standard 10.13 (Transfer Syntax) says that if the PACS has a lossy image, it doesn't have to expand that to a lossless format for us (which would be a bad idea anyway) - this PR allows the PACS to send us that data if that's what it's got.