### PR TITLE
Feature/updatedotnet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,8 @@ script:
     cd Plugin/net461
     dotnet publish --runtime win-x64 -c Release --self-contained false
     cd ../netcoreapp2.2
-    dotnet publish --runtime win-x64 -c Release --self-contained false
-    dotnet publish --runtime linux-x64 -c Release --self-contained false
+    dotnet publish --runtime win-x64 -c Release --self-contained false -o bin/Release/netcoreapp2.2/win-x64/publish
+    dotnet publish --runtime linux-x64 -c Release --self-contained false -o bin/Release/netcoreapp2.2/linux-x64/publish
     cd ../..
     nuget pack ./Rdmp.Dicom.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${RDVERSION}
     nuget pack ./Rdmp.Dicom.Library.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${RDVERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,6 @@ install:
     echo "ServerName: localhost" > Rdmp.Dicom.Tests/TestDatabases.txt
     echo "Prefix: TEST_" >> Rdmp.Dicom.Tests/TestDatabases.txt
     choco install sql-server-2017
-    choco install dotnetcore --version=2.2.2
-    choco install dotnetcore-sdk
     choco install nuget.commandline
     $HOME/rdmp-cli/rdmp.exe install localhost TEST_
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ install:
   then
     sudo apt-get install -y --no-install-recommends mssql-tools mssql-server libc6-dev libgdiplus dotnet-runtime-2.2 dotnet-sdk-3.1
     sudo /opt/mssql/bin/mssql-conf -n setup accept-eula
-    if [ ! -x $HOME/rdmp-cli/rdmp ] || ! fgrep -q 4.1.0 $HOME/rdmp-cli/rdmp.dll
+    if [ ! -x $HOME/rdmp-cli/rdmp ] || ! fgrep -q 4.1.8 $HOME/rdmp-cli/rdmp.dll
     then
       rm -rf $HOME/rdmp-cli
-      wget https://github.com/HicServices/RDMP/releases/download/v4.1.0/rdmp-cli-linux-x64.zip
+      wget https://github.com/HicServices/RDMP/releases/download/v4.1.8/rdmp-cli-linux-x64.zip
       # RDMP is still being packaged using a ZIP tool with a bug Microsoft fixed in .Net 4.6.1; excluding Chinese language support file and keyword help avoids unzip being affected by the bug: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-ziparchiveentry-fullname-path-separator?redirectedfrom=MSDN
       unzip -d $HOME/rdmp-cli rdmp-cli-linux-x64.zip -x "Curation*" "zh-*"
       chmod +x $HOME/rdmp-cli/rdmp
@@ -51,10 +51,10 @@ install:
 - |
   if [ "$TRAVIS_OS_NAME" = "windows" ]
   then
-    if [ ! -x $HOME/rdmp-cli/rdmp.exe ] || ! fgrep -q 4.1.0 $HOME/rdmp-cli/rdmp.dll
+    if [ ! -x $HOME/rdmp-cli/rdmp.exe ] || ! fgrep -q 4.1.8 $HOME/rdmp-cli/rdmp.dll
     then
       rm -rf $HOME/rdmp-cli
-      wget https://github.com/HicServices/RDMP/releases/download/v4.1.0/rdmp-cli-win-x64.zip
+      wget https://github.com/HicServices/RDMP/releases/download/v4.1.8/rdmp-cli-win-x64.zip
       7z x rdmp-cli-win-x64.zip -o$HOME/rdmp-cli
     fi
     echo "ServerName: localhost" > Rdmp.Dicom.Tests/TestDatabases.txt
@@ -75,8 +75,8 @@ script:
     cd Plugin/net461
     dotnet publish --runtime win-x64 -c Release --self-contained false
     cd ../netcoreapp2.2
-    dotnet publish --runtime win-x64 -c Release --self-contained false -o bin/Release/netcoreapp2.2/win-x64/publish
-    dotnet publish --runtime linux-x64 -c Release --self-contained false -o bin/Release/netcoreapp2.2/linux-x64/publish
+    dotnet publish --runtime win-x64 -c Release --self-contained false
+    dotnet publish --runtime linux-x64 -c Release --self-contained false
     cd ../..
     nuget pack ./Rdmp.Dicom.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${RDVERSION}
     nuget pack ./Rdmp.Dicom.Library.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${RDVERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
     echo "ServerName: localhost" > Rdmp.Dicom.Tests/TestDatabases.txt
     echo "Prefix: TEST_" >> Rdmp.Dicom.Tests/TestDatabases.txt
     choco install sql-server-2017
+    choco install dotnetcore-sdk
     choco install nuget.commandline
     $HOME/rdmp-cli/rdmp.exe install localhost TEST_
   fi

--- a/Plugin/netcoreapp2.2/netcoreapp2.2.csproj
+++ b/Plugin/netcoreapp2.2/netcoreapp2.2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{2C29B565-F0B0-4E5B-B17E-106456933001}</ProjectGuid>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>Rdmp.Dicom.Plugin</AssemblyTitle>
     <Product>Rdmp.Dicom.Plugin</Product>
     <Copyright>Copyright ©  2019</Copyright>

--- a/Rdmp.Dicom.nuspec
+++ b/Rdmp.Dicom.nuspec
@@ -13,10 +13,10 @@
     <file src="Plugin\net461\bin\$configuration$\net461\win-x64\publish\*"
           exclude="**/net461.dll;**\BadMedicine.Core.dll;**\FAnsi.*;**\MapsDirectlyToDatabaseTable.dll;**\MySql.Data.dll;**\Oracle.ManagedDataAccess.dll;**\Rdmp.Core.dll;**\NPOI.*;**\Renci.*;**\MathNet.Numerics.dll*;**\Rdmp.UI.dll;**\ScintillaNET.dll;**\ReusableUIComponents.dll;**\ObjectListView.dll;**\WeifenLuo.WinFormsUI.Docking*"
           target="lib\net461" />
-	<file src="Plugin\netcoreapp2.2\bin\$configuration$\netcoreapp2.2\win-x64\publish\*" 
+	<file src="Plugin\netcoreapp2.2\bin\$configuration$\netstandard2.0\win-x64\publish\*" 
         exclude="**\Plugin.dll;**\BadMedicine.Core.dll;**\FAnsi.*;**\MapsDirectlyToDatabaseTable.dll;**\MySql.Data.dll;**\Oracle.ManagedDataAccess.dll;**\Rdmp.Core.dll;**\NPOI.*;**\Renci.*;**\MathNet.Numerics.dll*"  
         target="lib\netcoreapp2.2\win\" />
-    <file src="Plugin\netcoreapp2.2\bin\$configuration$\netcoreapp2.2\linux-x64\publish\*" 
+    <file src="Plugin\netcoreapp2.2\bin\$configuration$\netstandard2.0\linux-x64\publish\*" 
           exclude="**\Plugin.dll;**\BadMedicine.Core.dll;**\FAnsi.*;**\MapsDirectlyToDatabaseTable.dll;**\MySql.Data.dll;**\Oracle.ManagedDataAccess.dll;**\Rdmp.Core.dll;**\NPOI.*;**\Renci.*;**\MathNet.Numerics.dll*"  
           target="lib\netcoreapp2.2\linux\" />
   </files>


### PR DESCRIPTION
- Update non-GUI plugin to target .Net Standard 2.0 rather than (deprecated) Core 2.2
- Run Travis integration tests against RDMP 4.1.8 rather than 4.1.0 (fixes existing silent failure in CI)