### PR TITLE
Feature/study timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## Added
+
+- Consecutively failing requests now result in delaying the fetch (incase server is busy with something)
+
 ## Fixed
 
 - In PACSSource TransferTimeOutInSeconds now applies only to the current study being fetched (not the whole hour)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## Fixed
+
+- In PACSSource TransferTimeOutInSeconds now applies only to the current study being fetched (not the whole hour)
+- Properly reported Warning and Cancel statuses in fetch request responses in PACSSource
+
 ## [2.1.9] 2020-08-28
 
 - Refactor PACS fetch code with simpler queue handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Consecutively failing requests now result in delaying the fetch (incase server is busy with something)
+- Added retry on failure/warning when fetching from PACS
 
 ## Fixed
 

--- a/Rdmp.Dicom.Tests/Integration/ExecuteCommandPacsFetchTest.cs
+++ b/Rdmp.Dicom.Tests/Integration/ExecuteCommandPacsFetchTest.cs
@@ -15,7 +15,7 @@ namespace Rdmp.Dicom.Tests.Integration
         public void TestLocal()
         {
             
-            var cmd = new ExecuteCommandPacsFetch(new ConsoleInputManager(RepositoryLocator, new ThrowImmediatelyCheckNotifier()){DisallowInput= true},"2010-01-01","2020-01-01","www.dicomserver.co.uk",104,"you","localhost",23,"me",TestContext.CurrentContext.WorkDirectory);
+            var cmd = new ExecuteCommandPacsFetch(new ConsoleInputManager(RepositoryLocator, new ThrowImmediatelyCheckNotifier()){DisallowInput= true},"2010-01-01","2020-01-01","www.dicomserver.co.uk",104,"you","localhost",23,"me",TestContext.CurrentContext.WorkDirectory,0);
             cmd.Execute();
         }
     }

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -66,16 +66,16 @@ namespace Rdmp.Dicom.Cache.Pipeline
 
         [DemandsInitialization("Ignore whitelist of patient identifiers",defaultValue: false, mandatory: true)]
         public bool IgnoreWhiteList { get; set; }
-
+        
+        /// <summary>
+        /// The maximum number of tries to fetch a given Study from the PACS.  Note that retries requests might not be issued immediately after
+        /// a failure.
+        /// </summary>
         [DemandsInitialization("Maximum number of times to re-request a Study when a Failure is encountered",defaultValue:3 , mandatory: true)]
         public int MaxRetries { get; set; } = 3;
 
         private HashSet<string> _whitelist;
 
-        /// <summary>
-        /// The maximum number of tries to fetch a given Study from the PACS.  Note that retries requests might not be issued immediately after
-        /// a failure.
-        /// </summary>
 
         public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -67,8 +67,8 @@ namespace Rdmp.Dicom.Cache.Pipeline
         [DemandsInitialization("Ignore whitelist of patient identifiers",defaultValue: false, mandatory: true)]
         public bool IgnoreWhiteList { get; set; }
 
-        [DemandsInitialization("Set the DICOM priority (recommended value for NHS transfers is low)", defaultValue: DicomPriority.Low, mandatory: true)]
-        public DicomPriority Priority { get; set; }
+        [DemandsInitialization("Maximum number of times to re-request a Study when a Failure is encountered",defaultValue:3 , mandatory: true)]
+        public int MaxRetries { get; set; } = 3;
 
         private HashSet<string> _whitelist;
 
@@ -76,7 +76,6 @@ namespace Rdmp.Dicom.Cache.Pipeline
         /// The maximum number of tries to fetch a given Study from the PACS.  Note that retries requests might not be issued immediately after
         /// a failure.
         /// </summary>
-        const int MaxRetries = 3;
 
         public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
@@ -400,8 +399,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                 RequestCooldownInMilliseconds = 1000 * RequestCooldownInSeconds,
                 TransferCooldownInMilliseconds = 1000 * TransferCooldownInSeconds,
                 TransferPollingInMilliseconds = 1000 * TransferPollingInSeconds,
-                TransferTimeOutInMilliseconds = 1000 * TransferTimeOutInSeconds,
-                Priority = Priority,
+                TransferTimeOutInMilliseconds = 1000 * TransferTimeOutInSeconds
             };
         }
         #endregion

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -184,7 +184,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                                 case DicomState.Failure :
                                     consecutiveFailures++;
                                     
-                                    if(MaxRetries < current.RetryCount)
+                                    if(current.RetryCount < MaxRetries)
                                     {
                                         // put it back in the bag with a increased retry count
                                         current.RetryCount++;

--- a/Rdmp.Dicom/Cache/Pipeline/StudyToFetch.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/StudyToFetch.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+namespace Rdmp.Dicom.Cache.Pipeline
+{
+    public class StudyToFetch
+    {
+        /// <summary>
+        /// The unique UID of the study that is to be fetched
+        /// </summary>
+        public string StudyUid {get;private set; }
+
+        /// <summary>
+        /// The number of times this study has been reported as unavailable or errors have manifested downloading it during
+        /// a single fetching session
+        /// </summary>
+        public int RetryCount {get;set;}
+
+        public StudyToFetch(string studyUid)
+        {
+            this.StudyUid = studyUid;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is StudyToFetch fetch &&
+                   StudyUid == fetch.StudyUid;
+        }
+
+        public override int GetHashCode()
+        {
+            return -1281949388 + EqualityComparer<string>.Default.GetHashCode(StudyUid);
+        }
+    }
+}

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandPacsFetch.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandPacsFetch.cs
@@ -23,7 +23,7 @@ namespace Rdmp.Dicom.CommandExecution
         private BackfillCacheFetchRequest _request;
         private PACSSource _source;
 
-        public ExecuteCommandPacsFetch(IBasicActivateItems activator,string start, string end, string remoteAeUri, int remotePort,string remoteAeTitle, string localAeUri, int localPort, string localAeTitle, string outDir):base(activator)
+        public ExecuteCommandPacsFetch(IBasicActivateItems activator,string start, string end, string remoteAeUri, int remotePort,string remoteAeTitle, string localAeUri, int localPort, string localAeTitle, string outDir, int maxRetries):base(activator)
         {
             var startDate = DateTime.Parse(start);   
             var endDate =  DateTime.Parse(end);   
@@ -50,6 +50,7 @@ namespace Rdmp.Dicom.CommandExecution
             _source.LocalAETitle = localAeTitle;
             _source.TransferTimeOutInSeconds = 50000;
             _source.Modality = "ALL";
+            _source.MaxRetries = maxRetries;
 
             _request = new BackfillCacheFetchRequest(BasicActivator.RepositoryLocator.CatalogueRepository,startDate);
             _request.ChunkPeriod = endDate.Subtract(startDate);


### PR DESCRIPTION
## Added

- Consecutively failing requests now result in delaying the fetch (incase server is busy with something)
- Added retry on failure/warning when fetching from PACS

## Fixed

- In PACSSource TransferTimeOutInSeconds now applies only to the current study being fetched (not the whole hour)
- Properly reported Warning and Cancel statuses in fetch request responses in PACSSource

