### PR TITLE
Refactored PACSSource to have an abstract base class and added CFindS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This plugin adds the following commands to RDMP CLI:
 ```
 ./rdmp cmd CFind 2001-01-01 2020-01-01 www.dicomserver.co.uk 104 you me .
 ```
-_Connects to the given PACS and writes CFInd response for date range into output file_
+_Connects to the given PACS and writes CFind response for date range into output file (note that the . denotes current directory)_
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ nuget pack ./Rdmp.Dicom.nuspec -Properties Configuration=Release -IncludeReferen
 ```
 
 This will produce a nupkg file (e.g. Rdmp.Dicom.0.0.1.nupkg) which can be consumed by both the RDMP client and dot net core RDMP CLI.
+
+
+# New CLI Commands
+
+This plugin adds the following commands to RDMP CLI:
+
+```
+./rdmp cmd CFind 2001-01-01 2020-01-01 www.dicomserver.co.uk 104 you me .
+```
+_Connects to the given PACS and writes CFInd response for date range into output file_
+
+
+```
+./rdmp cmd PACSFetch 2001-01-01 2020-01-01 www.dicomserver.co.uk 104 you localhost 104 me . 0
+```
+_Connects to the given PACS and fetches all images between the date ranges (requires firewall allows incomming connections from destination server)_
+

--- a/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
+++ b/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
@@ -31,7 +31,8 @@ namespace Rdmp.Dicom.Tests.Unit
                 dir.FullName, 0);
             cmd.Execute();
 
-            var f = Path.Combine(dir.FullName, @"out/Data/Cache/ALL/2010-01-01.csv");
+            // file name is miday on 2010 1st January
+            var f = Path.Combine(dir.FullName, @"out/Data/Cache/ALL/20100101120000.csv");
             FileAssert.Exists(f);
             
             var result = File.ReadAllLines(f);

--- a/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
+++ b/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using Rdmp.Core.CommandLine.Interactive;
+using Rdmp.Dicom.Cache.Pipeline;
+using Rdmp.Dicom.CommandExecution;
+using ReusableLibraryCode.Checks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Tests.Common;
+
+namespace Rdmp.Dicom.Tests.Unit
+{
+    class CFindSourceTests : UnitTests
+    {
+        [Test]
+        public void TestRunFindOn_PublicServer()
+        {
+            var dir = new DirectoryInfo(TestContext.CurrentContext.WorkDirectory);
+
+            var cmd = new ExecuteCommandCFind(
+                new ConsoleInputManager(RepositoryLocator, new ThrowImmediatelyCheckNotifier()) { DisallowInput = true },
+                "2010-01-01",
+                "2020-01-01",
+                "www.dicomserver.co.uk",
+                104,
+                "you",
+                "localhost",
+                23,
+                "me",
+                dir.FullName, 0);
+            cmd.Execute();
+
+            var f = Path.Combine(dir.FullName, @"out/Data/Cache/ALL/2010-01-01.csv");
+            FileAssert.Exists(f);
+            
+            var result = File.ReadAllLines(f);
+
+            // should be at least 1 image in the public test server
+            Assert.GreaterOrEqual(result.Length,2);
+        }
+    }
+}

--- a/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
+++ b/Rdmp.Dicom.Tests/Unit/CFindSourceTests.cs
@@ -25,10 +25,8 @@ namespace Rdmp.Dicom.Tests.Unit
                 "www.dicomserver.co.uk",
                 104,
                 "you",
-                "localhost",
-                23,
                 "me",
-                dir.FullName, 0);
+                dir.FullName);
             cmd.Execute();
 
             // file name is miday on 2010 1st January

--- a/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
@@ -1,0 +1,145 @@
+using Dicom;
+using Dicom.Network;
+using ReusableLibraryCode.Progress;
+using Rdmp.Dicom.Cache.Pipeline.Dicom;
+using Rdmp.Core.Caching.Requests;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.Curation;
+using DicomClient = Dicom.Network.Client.DicomClient;
+using CsvHelper;
+using System.IO;
+using CsvHelper.Configuration;
+using System.Globalization;
+using System.Threading;
+using DicomTypeTranslation;
+using System;
+
+namespace Rdmp.Dicom.Cache.Pipeline
+{
+
+    /// <summary>
+    /// Queries a remote PACS and downloads metadata into CSV ready for loading to a relational database.  This component does not fetch actual images
+    /// </summary>
+    public class CFindSource : SMICacheSource
+    {
+        private DicomTag[] _tagsToWrite = new DicomTag[] {
+            DicomTag.StudyInstanceUID,
+            DicomTag.PatientID,
+            DicomTag.StudyDate,
+            DicomTag.StudyTime,
+            DicomTag.StudyDescription,
+            DicomTag.ModalitiesInStudy
+        };
+
+        public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
+        {
+            listener.OnNotify(this,new NotifyEventArgs(ProgressEventType.Information,$"CFindSource version is {typeof(CFindSource).Assembly.GetName().Version}.  Assembly is {typeof(PACSSource).Assembly} " ));
+            listener.OnNotify(this,new NotifyEventArgs(ProgressEventType.Information,$"Fo-Dicom version is {typeof(DicomClient).Assembly.GetName().Version}.  Assembly is {typeof(DicomClient).Assembly} " ));
+
+            var dicomConfiguration = GetConfiguration();
+            var requestSender = new DicomRequestSender(dicomConfiguration, listener);
+            var dateFrom = Request.Start;
+            var dateTo = Request.End;
+            CachingSCP.LocalAet = LocalAETitle;
+            CachingSCP.Listener = listener;
+
+            if (PatientIdWhitelistColumnInfo != null && !IgnoreWhiteList)
+                GetWhitelist(listener);
+
+            //temp dir
+            var cacheDir = new LoadDirectory(Request.CacheProgress.LoadProgress.LoadMetadata.LocationOfFlatFiles).Cache;
+            var cacheLayout = new SMICacheLayout(cacheDir, new SMICachePathResolver(Modality));
+            
+            Chunk = new SMIDataChunk(Request)
+            {
+                FetchDate = dateFrom,
+                Modality = Modality,
+                Layout = cacheLayout
+            };
+
+            // Create filepath for the results of the C-Find
+            var workingDirectory = cacheLayout.GetLoadCacheDirectory(listener);
+            var filename = $"{dateFrom:yyyy-MM-dd}.csv";
+            var filepath = Path.Combine(workingDirectory.FullName, filename);
+
+            var sw = new StreamWriter(filepath);
+            var writer = new CsvWriter(sw,new CsvConfiguration(CultureInfo.CurrentCulture));
+
+            WriteHeaders(writer);
+                        
+            DicomClient client = new DicomClient(dicomConfiguration.RemoteAetUri.Host, dicomConfiguration.RemoteAetUri.Port, false, dicomConfiguration.LocalAetTitle, dicomConfiguration.RemoteAetTitle);
+                
+            try
+            {
+                // Find a list of studies
+                #region Query
+
+                listener.OnNotify(this,
+                    new NotifyEventArgs(ProgressEventType.Information,
+                        "Requesting Studies from " + dateFrom + " to " + dateTo));
+                int responses = 0;
+
+                var request = CreateStudyRequestByDateRangeForModality(dateFrom, dateTo, Modality);
+                request.OnResponseReceived += (req, response) =>
+                {
+                    if (Filter(Whitelist, response)) {
+                        Interlocked.Increment(ref responses);
+                        WriteResult(writer,response);
+                        }
+
+                };
+                requestSender.ThrottleRequest(request,client, cancellationToken.AbortToken);
+                listener.OnNotify(this,
+                    new NotifyEventArgs(ProgressEventType.Debug,
+                        "Total filtered studies for " + dateFrom + " to " + dateTo +"is " + responses));
+                #endregion
+
+            }
+            finally
+            {
+                writer.Dispose();
+            }
+            
+
+            return Chunk;
+        }
+
+        private void WriteHeaders(CsvWriter writer)
+        {
+            foreach(var t in _tagsToWrite)
+            {
+                var colName = DicomTypeTranslaterReader.GetColumnNameForTag(t,false);
+                writer.WriteField(colName);
+            }
+
+            writer.NextRecord();
+        }
+
+        private void WriteResult(CsvWriter writer, DicomCFindResponse response)
+        {
+            if (!response.HasDataset)
+                return;
+
+            foreach (var t in _tagsToWrite)
+            {
+                WriteValue(writer, response,t);
+            }
+
+            writer.NextRecord();
+        }
+
+        private void WriteValue(CsvWriter writer, DicomCFindResponse response, DicomTag tag)
+        {
+            var val = DicomTypeTranslaterReader.GetCSharpValue(response.Dataset, tag);
+
+            if(val == null)
+            {
+                writer.WriteField("");
+            }
+            else
+            {
+                writer.WriteField(DicomTypeTranslater.Flatten(val));                
+            }
+        }
+    }
+}

--- a/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
@@ -59,7 +59,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
 
             // Create filepath for the results of the C-Find
             var workingDirectory = cacheLayout.GetLoadCacheDirectory(listener);
-            var filename = $"{dateFrom:yyyy-MM-dd}.csv";
+            var filename = $"{dateFrom:yyyyMMddhhmmss}.csv";
             var filepath = Path.Combine(workingDirectory.FullName, filename);
 
             var sw = new StreamWriter(filepath);

--- a/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
@@ -19,6 +19,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
 
     /// <summary>
     /// Queries a remote PACS and downloads metadata into CSV ready for loading to a relational database.  This component does not fetch actual images
+    /// Combine this with <see cref="SMICacheDestination"/> but make sure to set the <see cref="SMICacheDestination.Extension"/> to "*.csv"
     /// </summary>
     public class CFindSource : SMICacheSource
     {

--- a/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/CFindSource.cs
@@ -92,7 +92,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                 requestSender.ThrottleRequest(request,client, cancellationToken.AbortToken);
                 listener.OnNotify(this,
                     new NotifyEventArgs(ProgressEventType.Debug,
-                        "Total filtered studies for " + dateFrom + " to " + dateTo +"is " + responses));
+                        "Total filtered studies for " + dateFrom + " to " + dateTo +" is " + responses));
                 #endregion
 
             }

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -1,69 +1,24 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Dicom;
 using Dicom.Network;
-using MapsDirectlyToDatabaseTable;
-using ReusableLibraryCode.Checks;
-using ReusableLibraryCode.DataAccess;
 using ReusableLibraryCode.Progress;
 using Rdmp.Dicom.Cache.Pipeline.Dicom;
-using Rdmp.Dicom.PACS;
 using Timer = System.Timers.Timer;
 using Rdmp.Core.Curation.Data;
-using Rdmp.Core.Caching.Pipeline.Sources;
 using Rdmp.Core.Caching.Requests;
 using Rdmp.Core.DataFlowPipeline;
 using Rdmp.Core.Curation;
-using Rdmp.Core.QueryBuilding;
 using DicomClient = Dicom.Network.Client.DicomClient;
 using System.Collections.Concurrent;
 
 namespace Rdmp.Dicom.Cache.Pipeline
 {
-    public class PACSSource : CacheSource<SMIDataChunk>
+    public class PACSSource : SMICacheSource
     {
         
-        [DemandsInitialization("Remote Application Entity of the PACS server",mandatory:true)]
-        public string RemoteAETitle { get; set; }
-
-        [DemandsInitialization("Where the remote PACS server is", mandatory: true)]
-        public Uri RemoteAEUri { get; set; }
-
-        [DemandsInitialization("The port to send the request to on the remote PACS server", mandatory: true)]
-        public int RemoteAEPort { get; set; }
-        
-        [DemandsInitialization("Local Application Entity title of your computer/software", mandatory: true)]
-        public string LocalAETitle { get; set; }
-
-        [DemandsInitialization("Local AE Uri of your computer", mandatory: true)]
-        public Uri LocalAEUri { get; set; }
-
-        [DemandsInitialization("The type of imaging to be cached, using the relevant acronym from the DICOM standard. e.g. CT,MR", mandatory: true)]
-        public string Modality { get; set; }
-
-        [DemandsInitialization("The port to listen on for responses", defaultValue: 2104, mandatory: true)]
-        public int LocalAEPort { get; set; }
-
-        [DemandsInitialization("Cooldown (in seconds) after a successful request", defaultValue: 60, mandatory: true)]
-        public int RequestCooldownInSeconds { get; set; }
-
-        [DemandsInitialization("Cooldown (in seconds) after a successful transfer", defaultValue: 120, mandatory: true)]
-        public int TransferCooldownInSeconds { get; set; }
-
-        [DemandsInitialization("Polling (in seconds) for successful transfer", defaultValue: 1, mandatory: true)]
-        public int TransferPollingInSeconds { get; set; }
-
-        [DemandsInitialization("Timeout period (in seconds) for unsuccessful transfer", defaultValue: 120, mandatory: true)]
-        public int TransferTimeOutInSeconds { get; set; }
-
-        [DemandsInitialization("A column containing a whitelist of patient identifiers which are permitted to be downloaded")]
-        public ColumnInfo PatientIdWhitelistColumnInfo { get; set; }
-
-        [DemandsInitialization("Ignore whitelist of patient identifiers",defaultValue: false, mandatory: true)]
-        public bool IgnoreWhiteList { get; set; }
         
         /// <summary>
         /// The maximum number of tries to fetch a given Study from the PACS.  Note that retries requests might not be issued immediately after
@@ -72,7 +27,6 @@ namespace Rdmp.Dicom.Cache.Pipeline
         [DemandsInitialization("Maximum number of times to re-request a Study when a Failure is encountered",defaultValue:3 , mandatory: true)]
         public int MaxRetries { get; set; } = 3;
 
-        private HashSet<string> _whitelist;
 
 
         public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
@@ -128,7 +82,7 @@ namespace Rdmp.Dicom.Cache.Pipeline
                     var request = CreateStudyRequestByDateRangeForModality(dateFrom, dateTo, Modality);
                     request.OnResponseReceived += (req, response) =>
                     {
-                        if (Filter(_whitelist, response))
+                        if (Filter(Whitelist, response))
                             studiesToOrder.Add(new StudyToFetch(response.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID)));
 
                     };
@@ -250,126 +204,8 @@ namespace Rdmp.Dicom.Cache.Pipeline
             return Chunk;
         }
 
-        private DicomCMoveRequest CreateCMoveByStudyUid(string destination, string studyUid, IDataLoadEventListener listener)
-        {
-            var request = new DicomCMoveRequest(destination, studyUid);
-            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "DicomRetriever.CreateCMoveByStudyUid created request for: " + studyUid));
-            // no more dicomtags have to be set
-            return request;
-        }
-        public override void Dispose(IDataLoadEventListener listener, Exception pipelineFailureExceptionIfAny)
-        {
-        }
-
-        public override void Abort(IDataLoadEventListener listener)
-        {
-        }
-
-        
-        public override SMIDataChunk TryGetPreview()
-        {
-            return null;
-        }
-
-        #region Check
-        public override void Check(ICheckNotifier notifier)
-        {
-            // ping configured remote PACS with a C-ECHO request
-            //use a new requestSender
-            var echoRequestSender = new DicomRequestSender(GetConfiguration(), new FromCheckNotifierToDataLoadEventListener(notifier));
-            echoRequestSender.OnRequestException += ex =>
-            {
-                notifier.OnCheckPerformed(new CheckEventArgs("Error sending ECHO", CheckResult.Fail, ex));
-            };
-            echoRequestSender.OnRequestTimeout += () => 
-            {
-                notifier.OnCheckPerformed(new CheckEventArgs("Failed to get response from server after timeout", CheckResult.Fail));
-            };
-            echoRequestSender.OnRequestSucess += () =>
-            {
-                notifier.OnCheckPerformed(new CheckEventArgs("Successfully received C-ECHO response from remote PACS", CheckResult.Success));
-            };
-
-            try
-            {
-                echoRequestSender.Check();
-            }
-            catch (Exception e)
-            {
-                notifier.OnCheckPerformed(new CheckEventArgs("Error when sending C-ECHO to remote PACS",CheckResult.Fail, e));
-            }
-        }
-        #endregion
-
-        #region CreateStudyRequestByDateRangeForModality
-        public static DicomCFindRequest CreateStudyRequestByDateRangeForModality(DateTime dateFrom, DateTime dateTo, string modality, DicomPriority priority= DicomPriority.Low)
-        {
-
-            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study,priority);
-
-            // always add the encoding - with agnostic encoding
-            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
-
-            // add the dicom tags with empty values that should be included in the result of the QR Server
-            request.Dataset.AddOrUpdate(DicomTag.PatientID, "");
-            request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, "");
-            request.Dataset.AddOrUpdate(DicomTag.StudyDescription, "");
-
-            string modalityToQuery = modality.Equals("all", StringComparison.OrdinalIgnoreCase) ? "" : modality;
-            // add the dicom tags that contain the filter criteria
-            request.Dataset.AddOrUpdate(DicomTag.ModalitiesInStudy, modalityToQuery);
-            var studyDateRange = new DicomDateRange(dateFrom, dateTo);
-            request.Dataset.AddOrUpdate(DicomTag.StudyDate, studyDateRange);
-            request.Dataset.AddOrUpdate(DicomTag.StudyTime, studyDateRange);
-            return request;
-        }
-        #endregion
-
-        #region CreateSeriesRequestByStudyUID
-        public static DicomCFindRequest CreateSeriesRequestByStudyUid(string studyInstanceUid, DicomPriority priority = DicomPriority.Low)
-        {
-            //create your own request that contains exactly those DicomTags that
-            // you realy need pro process your data and not to cause unneccessary traffic and IO load:
-            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series,priority);
-
-            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
-
-            // add the dicom tags with empty values that should be included in the result
-            request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, "");
-            request.Dataset.AddOrUpdate(DicomTag.SeriesDescription, "");
-            request.Dataset.AddOrUpdate(DicomTag.Modality, "");
-            request.Dataset.AddOrUpdate(DicomTag.NumberOfSeriesRelatedInstances, "");
-
-            // add the dicom tags that contain the filter criteria
-            request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, studyInstanceUid);
-
-            return request;
-        }
-        #endregion
-
-        #region CreateSopRequestBySeriesUID
-        public static DicomCFindRequest CreateSopRequestBySeriesUid(string seriesInstanceUid, DicomPriority priority = DicomPriority.Low)
-        {
-            //create your own request that contains exactly those DicomTags that
-            // you realy need pro process your data and not to cause unneccessary traffic and IO load:
-            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Image,priority);
-
-            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
-
-            // add the dicom tags with empty values that should be included in the result
-            request.Dataset.AddOrUpdate(DicomTag.PatientID, "");
-            request.Dataset.AddOrUpdate(DicomTag.SOPInstanceUID, "");
-            request.Dataset.AddOrUpdate(DicomTag.Modality, "");
-
-            // add the dicom tags that contain the filter criteria
-            request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, seriesInstanceUid);
-
-            return request;
-        }
-        #endregion
-
         #region SaveSopInstance
-        private void SaveSopInstance(DicomCStoreRequest request, SMICacheLayout cacheLayout, IDataLoadEventListener listener)
+        protected void SaveSopInstance(DicomCStoreRequest request, SMICacheLayout cacheLayout, IDataLoadEventListener listener)
         {
             var instUid = request.SOPInstanceUID.UID;
             if (!request.HasDataset)
@@ -381,80 +217,6 @@ namespace Rdmp.Dicom.Cache.Pipeline
             request.File.Save(filepath);
         }
         #endregion
-
-        #region GetConfiguration
-        private DicomConfiguration GetConfiguration()
-        {
-            return new DicomConfiguration
-            {
-                LocalAetTitle = LocalAETitle,
-                LocalAetUri = DicomConfiguration.MakeUriUsePort(LocalAEUri, LocalAEPort),
-                RemoteAetTitle = RemoteAETitle,
-                RemoteAetUri = DicomConfiguration.MakeUriUsePort(RemoteAEUri, RemoteAEPort),
-                RequestCooldownInMilliseconds = 1000 * RequestCooldownInSeconds,
-                TransferCooldownInMilliseconds = 1000 * TransferCooldownInSeconds,
-                TransferPollingInMilliseconds = 1000 * TransferPollingInSeconds,
-                TransferTimeOutInMilliseconds = 1000 * TransferTimeOutInSeconds
-            };
-        }
-        #endregion
-
-
-        #region GetWhitelist
-        private void GetWhitelist(IDataLoadEventListener listener)
-        {
-            _whitelist = new HashSet<string>();
-
-            var db = DataAccessPortal.GetInstance().ExpectDatabase(PatientIdWhitelistColumnInfo.TableInfo, DataAccessContext.DataLoad);
-            var server = db.Server;
-
-            var qb = new QueryBuilder("distinct", null);
-            qb.AddColumn(new ColumnInfoToIColumn(new MemoryRepository(), PatientIdWhitelistColumnInfo));
-
-            var sql = qb.SQL;
-
-            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "Downloading Whitelist with SQL:" + sql));
-
-            using (var con = server.GetConnection())
-            {
-                con.Open();
-                var r = server.GetCommand(sql, con).ExecuteReader();
-
-                while (r.Read())
-                {
-                    var o = r[PatientIdWhitelistColumnInfo.GetRuntimeName()];
-                    if (o == null || o == DBNull.Value)
-                        continue;
-
-                    _whitelist.Add(o.ToString());
-                }
-            }
-
-            listener.OnNotify(this, new NotifyEventArgs(_whitelist.Count == 0 ? ProgressEventType.Error : ProgressEventType.Information, "Whitelist contained " + _whitelist.Count + " identifiers"));
-        }
-        #endregion
-
-        #region Filter
-        private static bool Filter(HashSet<string> whitelistIfAny, DicomCFindResponse response)
-        {
-            var dataset = response.Dataset;
-
-            //ignore responses where there are no dataset record being returned
-            if (dataset == null)
-                return false;
-
-            //if there is a whitelist
-            if (whitelistIfAny == null) return true;
-            //get the response dataset patientId
-            var patientId = dataset.GetSingleValue<string>(DicomTag.PatientID);
-
-            //if the patientId is empty or not on our whitelist
-            return patientId != null && whitelistIfAny.Contains(patientId.Trim());
-
-            //No WhiteList just add
-        }
-        #endregion
- 
 
         #region CMoveRequestToString
         private string CMoveRequestToString(DicomCMoveRequest cMoveRequest, int attempt)

--- a/Rdmp.Dicom/Cache/Pipeline/SMICacheSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/SMICacheSource.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Generic;
+using Dicom;
+using Dicom.Network;
+using MapsDirectlyToDatabaseTable;
+using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.DataAccess;
+using ReusableLibraryCode.Progress;
+using Rdmp.Dicom.Cache.Pipeline.Dicom;
+using Rdmp.Dicom.PACS;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Caching.Pipeline.Sources;
+using Rdmp.Core.QueryBuilding;
+
+namespace Rdmp.Dicom.Cache.Pipeline
+{
+    /// <summary>
+    /// Abstract cache source for querying PACS servers
+    /// </summary>
+    public abstract class SMICacheSource : CacheSource<SMIDataChunk>
+    {
+        [DemandsInitialization("Remote Application Entity of the PACS server", mandatory: true)]
+        public string RemoteAETitle { get; set; }
+
+        [DemandsInitialization("Where the remote PACS server is", mandatory: true)]
+        public Uri RemoteAEUri { get; set; }
+
+        [DemandsInitialization("The port to send the request to on the remote PACS server", mandatory: true)]
+        public int RemoteAEPort { get; set; }
+
+        [DemandsInitialization("Local Application Entity title of your computer/software", mandatory: true)]
+        public string LocalAETitle { get; set; }
+
+        [DemandsInitialization("Local AE Uri of your computer", mandatory: true)]
+        public Uri LocalAEUri { get; set; }
+
+        [DemandsInitialization("The type of imaging to be cached, using the relevant acronym from the DICOM standard. e.g. CT,MR", mandatory: true)]
+        public string Modality { get; set; }
+
+        [DemandsInitialization("The port to listen on for responses", defaultValue: 2104, mandatory: true)]
+        public int LocalAEPort { get; set; }
+
+        [DemandsInitialization("Cooldown (in seconds) after a successful request", defaultValue: 60, mandatory: true)]
+        public int RequestCooldownInSeconds { get; set; }
+
+        [DemandsInitialization("Cooldown (in seconds) after a successful transfer", defaultValue: 120, mandatory: true)]
+        public int TransferCooldownInSeconds { get; set; }
+
+        [DemandsInitialization("Polling (in seconds) for successful transfer", defaultValue: 1, mandatory: true)]
+        public int TransferPollingInSeconds { get; set; }
+
+        [DemandsInitialization("Timeout period (in seconds) for unsuccessful transfer", defaultValue: 120, mandatory: true)]
+        public int TransferTimeOutInSeconds { get; set; }
+
+        [DemandsInitialization("A column containing a whitelist of patient identifiers which are permitted to be downloaded")]
+        public ColumnInfo PatientIdWhitelistColumnInfo { get; set; }
+
+        [DemandsInitialization("Ignore whitelist of patient identifiers", defaultValue: false, mandatory: true)]
+        public bool IgnoreWhiteList { get; set; }
+
+
+        protected HashSet<string> Whitelist;
+
+
+        protected DicomCMoveRequest CreateCMoveByStudyUid(string destination, string studyUid, IDataLoadEventListener listener)
+        {
+            var request = new DicomCMoveRequest(destination, studyUid);
+            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "DicomRetriever.CreateCMoveByStudyUid created request for: " + studyUid));
+            // no more dicomtags have to be set
+            return request;
+        }
+        public override void Dispose(IDataLoadEventListener listener, Exception pipelineFailureExceptionIfAny)
+        {
+        }
+
+        public override void Abort(IDataLoadEventListener listener)
+        {
+        }
+
+
+        public override SMIDataChunk TryGetPreview()
+        {
+            return null;
+        }
+
+        #region Check
+        public override void Check(ICheckNotifier notifier)
+        {
+            // ping configured remote PACS with a C-ECHO request
+            //use a new requestSender
+            var echoRequestSender = new DicomRequestSender(GetConfiguration(), new FromCheckNotifierToDataLoadEventListener(notifier));
+            echoRequestSender.OnRequestException += ex =>
+            {
+                notifier.OnCheckPerformed(new CheckEventArgs("Error sending ECHO", CheckResult.Fail, ex));
+            };
+            echoRequestSender.OnRequestTimeout += () =>
+            {
+                notifier.OnCheckPerformed(new CheckEventArgs("Failed to get response from server after timeout", CheckResult.Fail));
+            };
+            echoRequestSender.OnRequestSucess += () =>
+            {
+                notifier.OnCheckPerformed(new CheckEventArgs("Successfully received C-ECHO response from remote PACS", CheckResult.Success));
+            };
+
+            try
+            {
+                echoRequestSender.Check();
+            }
+            catch (Exception e)
+            {
+                notifier.OnCheckPerformed(new CheckEventArgs("Error when sending C-ECHO to remote PACS", CheckResult.Fail, e));
+            }
+        }
+        #endregion
+
+        #region CreateStudyRequestByDateRangeForModality
+        protected DicomCFindRequest CreateStudyRequestByDateRangeForModality(DateTime dateFrom, DateTime dateTo, string modality, DicomPriority priority = DicomPriority.Low)
+        {
+
+            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study, priority);
+
+            // always add the encoding - with agnostic encoding
+            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
+
+            // add the dicom tags with empty values that should be included in the result of the QR Server
+            request.Dataset.AddOrUpdate(DicomTag.PatientID, "");
+            request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, "");
+            request.Dataset.AddOrUpdate(DicomTag.StudyDescription, "");
+
+            string modalityToQuery = modality.Equals("all", StringComparison.OrdinalIgnoreCase) ? "" : modality;
+            // add the dicom tags that contain the filter criteria
+            request.Dataset.AddOrUpdate(DicomTag.ModalitiesInStudy, modalityToQuery);
+            var studyDateRange = new DicomDateRange(dateFrom, dateTo);
+            request.Dataset.AddOrUpdate(DicomTag.StudyDate, studyDateRange);
+            request.Dataset.AddOrUpdate(DicomTag.StudyTime, studyDateRange);
+            return request;
+        }
+        #endregion
+
+        #region CreateSeriesRequestByStudyUID
+        protected DicomCFindRequest CreateSeriesRequestByStudyUid(string studyInstanceUid, DicomPriority priority = DicomPriority.Low)
+        {
+            //create your own request that contains exactly those DicomTags that
+            // you realy need pro process your data and not to cause unneccessary traffic and IO load:
+            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series, priority);
+
+            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
+
+            // add the dicom tags with empty values that should be included in the result
+            request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, "");
+            request.Dataset.AddOrUpdate(DicomTag.SeriesDescription, "");
+            request.Dataset.AddOrUpdate(DicomTag.Modality, "");
+            request.Dataset.AddOrUpdate(DicomTag.NumberOfSeriesRelatedInstances, "");
+
+            // add the dicom tags that contain the filter criteria
+            request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, studyInstanceUid);
+
+            return request;
+        }
+        #endregion
+
+        #region CreateSopRequestBySeriesUID
+        protected DicomCFindRequest CreateSopRequestBySeriesUid(string seriesInstanceUid, DicomPriority priority = DicomPriority.Low)
+        {
+            //create your own request that contains exactly those DicomTags that
+            // you realy need pro process your data and not to cause unneccessary traffic and IO load:
+            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Image, priority);
+
+            request.Dataset.AddOrUpdate(new DicomTag(0x8, 0x5), "ISO_IR 100");
+
+            // add the dicom tags with empty values that should be included in the result
+            request.Dataset.AddOrUpdate(DicomTag.PatientID, "");
+            request.Dataset.AddOrUpdate(DicomTag.SOPInstanceUID, "");
+            request.Dataset.AddOrUpdate(DicomTag.Modality, "");
+
+            // add the dicom tags that contain the filter criteria
+            request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+
+            return request;
+        }
+        #endregion
+
+
+        #region GetConfiguration
+        protected DicomConfiguration GetConfiguration()
+        {
+            return new DicomConfiguration
+            {
+                LocalAetTitle = LocalAETitle,
+                LocalAetUri = DicomConfiguration.MakeUriUsePort(LocalAEUri, LocalAEPort),
+                RemoteAetTitle = RemoteAETitle,
+                RemoteAetUri = DicomConfiguration.MakeUriUsePort(RemoteAEUri, RemoteAEPort),
+                RequestCooldownInMilliseconds = 1000 * RequestCooldownInSeconds,
+                TransferCooldownInMilliseconds = 1000 * TransferCooldownInSeconds,
+                TransferPollingInMilliseconds = 1000 * TransferPollingInSeconds,
+                TransferTimeOutInMilliseconds = 1000 * TransferTimeOutInSeconds
+            };
+        }
+        #endregion
+
+
+        #region GetWhitelist
+
+        /// <summary>
+        /// Populates <see cref="Whitelist"/>
+        /// </summary>
+        /// <param name="listener"></param>
+        protected void GetWhitelist(IDataLoadEventListener listener)
+        {
+            Whitelist = new HashSet<string>();
+
+            var db = DataAccessPortal.GetInstance().ExpectDatabase(PatientIdWhitelistColumnInfo.TableInfo, DataAccessContext.DataLoad);
+            var server = db.Server;
+
+            var qb = new QueryBuilder("distinct", null);
+            qb.AddColumn(new ColumnInfoToIColumn(new MemoryRepository(), PatientIdWhitelistColumnInfo));
+
+            var sql = qb.SQL;
+
+            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "Downloading Whitelist with SQL:" + sql));
+
+            using (var con = server.GetConnection())
+            {
+                con.Open();
+                var r = server.GetCommand(sql, con).ExecuteReader();
+
+                while (r.Read())
+                {
+                    var o = r[PatientIdWhitelistColumnInfo.GetRuntimeName()];
+                    if (o == null || o == DBNull.Value)
+                        continue;
+
+                    Whitelist.Add(o.ToString());
+                }
+            }
+
+            listener.OnNotify(this, new NotifyEventArgs(Whitelist.Count == 0 ? ProgressEventType.Error : ProgressEventType.Information, "Whitelist contained " + Whitelist.Count + " identifiers"));
+        }
+        #endregion
+
+        #region Filter
+        protected bool Filter(HashSet<string> whitelistIfAny, DicomCFindResponse response)
+        {
+            var dataset = response.Dataset;
+
+            //ignore responses where there are no dataset record being returned
+            if (dataset == null)
+                return false;
+
+            //if there is a whitelist
+            if (whitelistIfAny == null) return true;
+            //get the response dataset patientId
+            var patientId = dataset.GetSingleValue<string>(DicomTag.PatientID);
+
+            //if the patientId is empty or not on our whitelist
+            return patientId != null && whitelistIfAny.Contains(patientId.Trim());
+
+            //No WhiteList just add
+        }
+        #endregion
+
+
+
+    }
+}

--- a/Rdmp.Dicom/Cache/SMICacheDestination.cs
+++ b/Rdmp.Dicom/Cache/SMICacheDestination.cs
@@ -15,6 +15,8 @@ namespace Rdmp.Dicom.Cache
         [DemandsInitialization("The modality of the dicom images e.g. CT, this must match the source components modality",Mandatory = true)]
         public string Modality { get; set; }
 
+        [DemandsInitialization("The file extension to look for in fetched data", Mandatory = true, DefaultValue = "*.dcm")]
+        public string Extension { get; set; } 
 
         public SMIDataChunk ProcessPipelineData(SMIDataChunk toProcess, IDataLoadEventListener listener, GracefulCancellationToken cancellationToken)
         {
@@ -26,11 +28,11 @@ namespace Rdmp.Dicom.Cache
             // todo: skip this and stream directly into an archive
             var archiveDate = toProcess.Request.Start;
             listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "Creating archive: " + toProcess.Layout.GetArchiveFileInfoForDate(archiveDate, listener).FullName));
-            toProcess.Layout.CreateArchive(archiveDate,listener);
+            toProcess.Layout.CreateArchive(archiveDate,listener, Extension);
 
-            // remove all the .dcm files
+            // remove all the .dcm/.csv files
             var workingDirectory = toProcess.Layout.GetLoadCacheDirectory(listener);
-            foreach (var file in workingDirectory.EnumerateFiles("*.dcm"))
+            foreach (var file in workingDirectory.EnumerateFiles(Extension))
                 file.Delete();
 
 

--- a/Rdmp.Dicom/Cache/SMICacheLayout.cs
+++ b/Rdmp.Dicom/Cache/SMICacheLayout.cs
@@ -19,10 +19,10 @@ namespace Rdmp.Dicom.Cache
             
         }
         
-        public void CreateArchive(DateTime archiveDate,IDataLoadEventListener listener)
+        public void CreateArchive(DateTime archiveDate,IDataLoadEventListener listener, string extension)
         {
             var downloadDirectory = GetLoadCacheDirectory(listener);
-            var dataFiles = downloadDirectory.EnumerateFiles("*.dcm").ToArray();
+            var dataFiles = downloadDirectory.EnumerateFiles(extension).ToArray();
             
             if (!dataFiles.Any())
                 return;

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandCFind.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandCFind.cs
@@ -19,7 +19,7 @@ namespace Rdmp.Dicom.CommandExecution
         private BackfillCacheFetchRequest _request;
         private CFindSource _source;
 
-        public ExecuteCommandCFind(IBasicActivateItems activator, string start, string end, string remoteAeUri, int remotePort, string remoteAeTitle, string localAeUri, int localPort, string localAeTitle, string outDir, int maxRetries) : base(activator)
+        public ExecuteCommandCFind(IBasicActivateItems activator, string start, string end, string remoteAeUri, int remotePort, string remoteAeTitle, string localAeTitle, string outDir) : base(activator)
         {
             var startDate = DateTime.Parse(start);
             var endDate = DateTime.Parse(end);
@@ -42,8 +42,6 @@ namespace Rdmp.Dicom.CommandExecution
                 RemoteAEUri = new Uri("http://" + remoteAeUri),
                 RemoteAEPort = remotePort,
                 RemoteAETitle = remoteAeTitle,
-                LocalAEUri = new Uri("http://" + localAeUri),
-                LocalAEPort = localPort,
                 LocalAETitle = localAeTitle,
                 TransferTimeOutInSeconds = 50000,
                 Modality = "ALL"

--- a/Rdmp.Dicom/PACS/DicomConfiguration.cs
+++ b/Rdmp.Dicom/PACS/DicomConfiguration.cs
@@ -12,6 +12,9 @@ namespace Rdmp.Dicom.PACS
         #region MakeUriUsePort
         public static Uri MakeUriUsePort(Uri uri, int? port)
         {
+            if (uri == null)
+                return null;
+
             //no explicit port specified
             if (!port.HasValue)
                 return uri;


### PR DESCRIPTION
This should create an alternative caching component called CFindSource that generates files like:

```
StudyInstanceUID,PatientID,StudyDate,StudyTime,StudyDescription,ModalitiesInStudy
1.2.826.0.1.3680043.11.117,PAT013,01/01/2017 00:00:00,00:00:00,,NM
```

These can be loaded into our database using a regular cache based data load so we can determine in database what studies to fetch.  

I looked at the fields returned by `https://www.dicomserver.co.uk/` and it is all study level data.  I am hoping that we can get what we need just from StudyDescription but if we need to dive to Series level tags (e.g. SeriesDescription) I think we will have to modify this a bit.