### PR TITLE
Switch asset uploader to allow prereleases in Github

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -22,9 +22,7 @@ jobs:
           for /f tokens^=1^,2^ delims^=^" %%i in (SharedAssemblyInfo.cs) do @if "%%i"=="[assembly: AssemblyVersion(" echo ::set-output name=version::%%j
           for /f tokens^=2^,4^ delims^=^" %%i in (Rdmp.Dicom/Rdmp.Dicom.csproj) do @if "%%i"=="HIC.RDMP.Plugin" echo ::set-output name=rdmpversion::%%j
       - name: Install MS SQL 2019
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install sql-server-2019 --params="'/IgnorePendingReboot'"
+        run: Choco-Install -PackageName sql-server-2019
       - name: Set up database
         run: |
           Invoke-WebRequest -Uri https://github.com/HicServices/RDMP/releases/download/v${{ steps.version.outputs.rdmpversion }}/rdmp-cli-win-x64.zip -OutFile rdmp.zip

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -57,8 +57,8 @@ jobs:
           retention-days: 1
       - name: Upload release binaries
         if: contains(github.ref,'refs/tags/')
-        uses: alexellis/upload-assets@0.2.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: svenstaro/upload-release-action@v2
         with:
-          asset_paths: '["Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg"]'
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file: '["Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg"]'


### PR DESCRIPTION
Fix for #136 - switch to an uploader that allows pre-releases to be upload targets. Will need to be replicated on all the other repos too...