### PR TITLE
Dicomclientopts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## Added
+
+- Added support for customising `DicomClient` client settings in PACSSource caching component (e.g. `AssociationLingerTimeoutInMs`)
+
 ## [3.0.0] 2021-06-05
 
 ### Changed

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -81,16 +81,16 @@ namespace Rdmp.Dicom.Cache.Pipeline
             {
                 DicomClient client = new DicomClient(dicomConfiguration.RemoteAetUri.Host, dicomConfiguration.RemoteAetUri.Port, false, dicomConfiguration.LocalAetTitle, dicomConfiguration.RemoteAetTitle);
 
-                if(AssociationLingerTimeoutInMs != null)
+                if(AssociationLingerTimeoutInMs != null && AssociationLingerTimeoutInMs > 0)
                     client.AssociationLingerTimeoutInMs = AssociationLingerTimeoutInMs.Value;
 
-                if(AssociationReleaseTimeoutInMs != null)
+                if(AssociationReleaseTimeoutInMs != null && AssociationReleaseTimeoutInMs > 0)
                     client.AssociationReleaseTimeoutInMs = AssociationReleaseTimeoutInMs.Value;
 
-                if(AssociationRequestTimeoutInMs != null)
+                if(AssociationRequestTimeoutInMs != null && AssociationRequestTimeoutInMs > 0)
                     client.AssociationRequestTimeoutInMs = AssociationRequestTimeoutInMs.Value;
 
-                if(MaximumNumberOfRequestsPerAssociation != null)
+                if(MaximumNumberOfRequestsPerAssociation != null && MaximumNumberOfRequestsPerAssociation > 0)
                     client.MaximumNumberOfRequestsPerAssociation = MaximumNumberOfRequestsPerAssociation.Value;
 
                 try

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -28,17 +28,17 @@ namespace Rdmp.Dicom.Cache.Pipeline
         public int MaxRetries { get; set; } = 3;
 
         [DemandsInitialization("The timeout (in ms) to wait for an association response after sending an association release request.  Defaults to 50ms if not specified")]
-        public int? AssociationLingerTimeoutInMs { get; private set; }
+        public int? AssociationLingerTimeoutInMs { get; set; }
 
         /// 
         [DemandsInitialization("The timeout (in ms) to wait for an association response after sending an association request.  Defaults to 10000ms if not specified")]
-        public int? AssociationReleaseTimeoutInMs { get; private set; }
+        public int? AssociationReleaseTimeoutInMs { get; set; }
 
         [DemandsInitialization("The timeout (in ms) that associations need to be held open after all requests have been processed.  Defaults to 5000ms if not specified")]
-        public int? AssociationRequestTimeoutInMs { get; private set; }
+        public int? AssociationRequestTimeoutInMs { get; set; }
 
         [DemandsInitialization("The maximum number of DICOM requests that are allowed to be sent over one single association.  When this limit is reached, the DICOM client will wait for pending requests to complete, and then open a new association to send the remaining requests, if any.  If not provided then int.MaxValue is used (i.e. keep reusing association)")]
-        public int? MaximumNumberOfRequestsPerAssociation { get; private set; }
+        public int? MaximumNumberOfRequestsPerAssociation { get; set; }
 
         public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -27,7 +27,18 @@ namespace Rdmp.Dicom.Cache.Pipeline
         [DemandsInitialization("Maximum number of times to re-request a Study when a Failure is encountered",defaultValue:3 , mandatory: true)]
         public int MaxRetries { get; set; } = 3;
 
+        [DemandsInitialization("The timeout (in ms) to wait for an association response after sending an association release request.  Defaults to 50ms if not specified")]
+        public int? AssociationLingerTimeoutInMs { get; private set; }
 
+        /// 
+        [DemandsInitialization("The timeout (in ms) to wait for an association response after sending an association request.  Defaults to 10000ms if not specified")]
+        public int? AssociationReleaseTimeoutInMs { get; private set; }
+
+        [DemandsInitialization("The timeout (in ms) that associations need to be held open after all requests have been processed.  Defaults to 5000ms if not specified")]
+        public int? AssociationRequestTimeoutInMs { get; private set; }
+
+        [DemandsInitialization("The maximum number of DICOM requests that are allowed to be sent over one single association.  When this limit is reached, the DICOM client will wait for pending requests to complete, and then open a new association to send the remaining requests, if any.  If not provided then int.MaxValue is used (i.e. keep reusing association)")]
+        public int? MaximumNumberOfRequestsPerAssociation { get; private set; }
 
         public override SMIDataChunk DoGetChunk(ICacheFetchRequest cacheRequest, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
@@ -69,7 +80,19 @@ namespace Rdmp.Dicom.Cache.Pipeline
             using (var server = (DicomServer<CachingSCP>) DicomServer.Create<CachingSCP>(dicomConfiguration.LocalAetUri.Port))
             {
                 DicomClient client = new DicomClient(dicomConfiguration.RemoteAetUri.Host, dicomConfiguration.RemoteAetUri.Port, false, dicomConfiguration.LocalAetTitle, dicomConfiguration.RemoteAetTitle);
-                
+
+                if(AssociationLingerTimeoutInMs != null)
+                    client.AssociationLingerTimeoutInMs = AssociationLingerTimeoutInMs.Value;
+
+                if(AssociationReleaseTimeoutInMs != null)
+                    client.AssociationReleaseTimeoutInMs = AssociationReleaseTimeoutInMs.Value;
+
+                if(AssociationRequestTimeoutInMs != null)
+                    client.AssociationRequestTimeoutInMs = AssociationRequestTimeoutInMs.Value;
+
+                if(MaximumNumberOfRequestsPerAssociation != null)
+                    client.MaximumNumberOfRequestsPerAssociation = MaximumNumberOfRequestsPerAssociation.Value;
+
                 try
                 {
                     // Find a list of studies


### PR DESCRIPTION
Pretty sure the 'too many associations' is bogus but just incase I have added control of the settings for lingering associations etc in as configurable.  They look like they have sensible defaults already though:

https://github.com/fo-dicom/fo-dicom/blob/9832ab62de7a79a1a78a19438df69581079f91b9/FO-DICOM.Core/Network/Client/DicomClientOptions.cs

We should keep an eye on this PR too:

https://github.com/fo-dicom/fo-dicom/pull/1144