### PR TITLE
Added SkipAnonymisationOnStructuredReports to FoDicomAnonymiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump HIC.RDMP.Plugin from 7.0.3 to 7.0.5
 
+### Added
+
+- Added SkipAnonymisationOnStructuredReports option to FoDicomAnonymiser
+
 ## [5.0.2] 2021-11-15
 
 - Added periodic disposal in ZipPool to prevent too many open file handles at once.

--- a/Rdmp.Dicom.Tests/Integration/FoDicomAnonymiserTests.cs
+++ b/Rdmp.Dicom.Tests/Integration/FoDicomAnonymiserTests.cs
@@ -192,6 +192,129 @@ namespace Rdmp.Dicom.Tests.Integration
                 Assert.AreEqual(value, anoDicom.Dataset.GetValue<string>(key, 0));
         }
 
+        [Test]
+        public void TestSkipAnonymisationOnStructuredReports()
+        {
+            var uidMapDb = GetCleanedServer(DatabaseType.MicrosoftSQLServer, "TESTUIDMapp");
+
+            MasterDatabaseScriptExecutor e = new MasterDatabaseScriptExecutor(uidMapDb);
+            var patcher = new SMIDatabasePatcher();
+            e.CreateAndPatchDatabase(patcher, new AcceptAllCheckNotifier());
+
+            var eds = new ExternalDatabaseServer(CatalogueRepository, "eds", patcher);
+            eds.SetProperties(uidMapDb);
+
+            Dictionary<DicomTag, string> thingThatShouldDisappear = new Dictionary<DicomTag, string>
+            {
+                //Things we would want to disappear
+                {DicomTag.PatientName,"Moscow"},
+                {DicomTag.PatientBirthDate,"20010101"},
+            };
+
+            Dictionary<DicomTag, string> thingsThatShouldRemain = new Dictionary<DicomTag, string>
+            {
+                //Things we would want to remain
+                {DicomTag.StudyDescription,"Frank has lots of problems, he lives at 60 Pancake road"},
+                {DicomTag.SeriesDescription,"Coconuts"},
+                {DicomTag.AlgorithmName,"Chessnuts"}, // would not normally be dropped by anonymisation
+                {DicomTag.StudyDate,"20020101"},
+            };
+
+            var dicom = new DicomDataset
+            {
+                {DicomTag.SOPInstanceUID, "123.4.4"},
+                {DicomTag.SeriesInstanceUID, "123.4.5"},
+                {DicomTag.StudyInstanceUID, "123.4.6"},
+                {DicomTag.SOPClassUID,"1"},
+                {DicomTag.Modality,"SR" } // its a structured report
+            };
+
+            foreach (var (key, value) in thingThatShouldDisappear)
+                dicom.AddOrUpdate(key, value);
+
+            foreach (var (key, value) in thingsThatShouldRemain)
+                dicom.AddOrUpdate(key, value);
+
+            dicom.AddOrUpdate(DicomTag.StudyDate, new DateTime(2002, 01, 01));
+
+            var fi = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "madness.dcm"));
+
+            DicomFile df = new DicomFile(dicom);
+            df.Save(fi.FullName);
+
+            var dt = new DataTable();
+            dt.Columns.Add("Filepath");
+            dt.Columns.Add("SOPInstanceUID");
+            dt.Columns.Add("SeriesInstanceUID");
+            dt.Columns.Add("StudyInstanceUID");
+            dt.Columns.Add("Pat");
+            //note we don't have series
+
+            dt.Rows.Add(fi.Name, "123.4.4", "123.4.5", "123.4.6", "Hank");
+
+            var anonymiser = new FoDicomAnonymiser();
+
+            IExtractCommand cmd = MockExtractionCommand();
+
+            //give the mock to anonymiser
+            anonymiser.PreInitialize(cmd, new ThrowImmediatelyDataLoadEventListener());
+
+            anonymiser.PutterType = typeof(PutInRoot);
+            anonymiser.ArchiveRootIfAny = TestContext.CurrentContext.WorkDirectory;
+            anonymiser.RelativeArchiveColumnName = "Filepath";
+            anonymiser.UIDMappingServer = eds;
+            anonymiser.RetainDates = false;
+            anonymiser.SkipAnonymisationOnStructuredReports = true; // <- the thing we are testing
+
+            var anoDt = anonymiser.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+
+            Assert.AreEqual(1, anoDt.Rows.Count);
+
+            //Data table should contain new UIDs
+            Assert.AreNotEqual("123.4.4", anoDt.Rows[0]["SOPInstanceUID"]);
+            Assert.AreEqual(56, anoDt.Rows[0]["SOPInstanceUID"].ToString().Length);
+
+            Assert.AreNotEqual("123.4.6", anoDt.Rows[0]["StudyInstanceUID"]);
+            Assert.AreEqual(56, anoDt.Rows[0]["StudyInstanceUID"].ToString().Length);
+            
+            var expectedFile = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "Images", anoDt.Rows[0]["SOPInstanceUID"] + ".dcm"));
+
+            Assert.IsTrue(expectedFile.Exists);
+            var anoDicom = DicomFile.Open(expectedFile.FullName);
+
+            Assert.AreEqual("Hank", anoDicom.Dataset.GetValue<string>(DicomTag.PatientID, 0));
+
+            Assert.AreEqual(anoDt.Rows[0]["SOPInstanceUID"], anoDicom.Dataset.GetValue<string>(DicomTag.SOPInstanceUID, 0));
+            Assert.AreEqual(56, anoDicom.Dataset.GetValue<string>(DicomTag.SeriesInstanceUID, 0).Length);
+
+            Assert.AreEqual(anoDt.Rows[0]["StudyInstanceUID"], anoDicom.Dataset.GetValue<string>(DicomTag.StudyInstanceUID, 0));
+
+
+            foreach (var (key, _) in thingThatShouldDisappear)
+            {
+                //if it chopped out the entire tag
+                if (!anoDicom.Dataset.Contains(key))
+                    continue;
+
+                if (anoDicom.Dataset.GetValueCount(key) == 0)
+                    continue;
+
+                var value = anoDicom.Dataset.GetSingleValue<string>(key);
+                switch (value)
+                {
+                    //allowed values
+                    case "ANONYMOUS": continue;
+
+                    default:
+                        Assert.Fail("Unexpected value for " + key + ":" + value);
+                        break;
+                }
+            }
+
+            foreach (var (key, value) in thingsThatShouldRemain)
+                Assert.AreEqual(value, anoDicom.Dataset.GetValue<string>(key, 0),$"Expected tag {key} to remain");
+        }
+
         // The following commented tests will fail due to underlying system limits on paths
         // there is no reliable method to get maximum path length (apparently?)
         //        [TestCase(typeof(PutInUidStudySeriesFolders))]

--- a/Rdmp.Dicom/Extraction/FoDicomBased/FoDicomAnonymiser.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/FoDicomAnonymiser.cs
@@ -14,6 +14,8 @@ using Rdmp.Core.DataFlowPipeline;
 using Rdmp.Core.Repositories.Construction;
 using MapsDirectlyToDatabaseTable.Versioning;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using static Dicom.DicomAnonymizer;
 
 namespace Rdmp.Dicom.Extraction.FoDicomBased
 {
@@ -88,20 +90,6 @@ namespace Rdmp.Dicom.Extraction.FoDicomBased
 
             var releaseCol = _extractCommand.QueryBuilder.SelectColumns.Select(c=>c.IColumn).Single(c=>c.IsExtractionIdentifier);
 
-            // See: ftp://medical.nema.org/medical/dicom/2011/11_15pu.pdf
-
-            var flags = DicomAnonymizer.SecurityProfileOptions.BasicProfile |
-                        DicomAnonymizer.SecurityProfileOptions.CleanStructdCont |
-                        DicomAnonymizer.SecurityProfileOptions.CleanDesc |
-                        DicomAnonymizer.SecurityProfileOptions.RetainUIDs;
-
-            if (RetainDates)
-              flags |= DicomAnonymizer.SecurityProfileOptions.RetainLongFullDates;
-
-            var profile = DicomAnonymizer.SecurityProfile.LoadProfile(null,flags);
-            
-            var anonymiser = new DicomAnonymizer(profile);
-
             var deleteTags = GetDeleteTags();
 
             using (var pool = new ZipPool())
@@ -137,27 +125,39 @@ namespace Rdmp.Dicom.Extraction.FoDicomBased
 
                     try
                     {
-                        if(SkipAnonymisationOnStructuredReports)
-                        {
-                            // do not anonymise SRs
+                        // do not anonymise SRs if this flag is set
+                        bool skipAnon = SkipAnonymisationOnStructuredReports && dicomFile.Dataset.GetSingleValue<string>(DicomTag.Modality) == "SR";
+                        
+                        // See: ftp://medical.nema.org/medical/dicom/2011/11_15pu.pdf
+                        var flags = skipAnon ?
+                            //dont anonymise
+                            DicomAnonymizer.SecurityProfileOptions.RetainSafePrivate |
+                            DicomAnonymizer.SecurityProfileOptions.RetainDeviceIdent|
+                            DicomAnonymizer.SecurityProfileOptions.RetainInstitutionIdent |
+                            DicomAnonymizer.SecurityProfileOptions.RetainUIDs |
+                            DicomAnonymizer.SecurityProfileOptions.RetainLongFullDates |
+                            DicomAnonymizer.SecurityProfileOptions.RetainPatientChars :
+                            // do anonymise
+                            DicomAnonymizer.SecurityProfileOptions.BasicProfile |
+                            DicomAnonymizer.SecurityProfileOptions.CleanStructdCont |
+                            DicomAnonymizer.SecurityProfileOptions.CleanDesc |
+                            DicomAnonymizer.SecurityProfileOptions.RetainUIDs;
 
-                            var modality = dicomFile.Dataset.GetSingleValue<string>(DicomTag.Modality);
-                            if (modality == "SR")
-                            {
-                                // its an SR so don't anonymise it
-                                ds = dicomFile.Dataset.Clone();
-                            }
-                            else
-                            {
-                                // its not an SR
-                                ds = anonymiser.Anonymize(dicomFile.Dataset);
-                            }
-                        }
-                        else
-                        {
-                            // anonymise everything
-                            ds = anonymiser.Anonymize(dicomFile.Dataset);
-                        }
+                        if (RetainDates && !skipAnon)
+                            flags |= DicomAnonymizer.SecurityProfileOptions.RetainLongFullDates;
+
+                        var profile = DicomAnonymizer.SecurityProfile.LoadProfile(null, flags);
+
+
+                        // I know we said skip anonymisation but still remove this stuff cmon
+                        if (skipAnon)
+                            RemovePatientNameEtc(profile);
+
+                        var anonymiser = new DicomAnonymizer(profile);
+
+                        
+                        ds = anonymiser.Anonymize(dicomFile.Dataset);
+                        
                     }
                     catch (Exception e)
                     {
@@ -210,6 +210,13 @@ namespace Rdmp.Dicom.Extraction.FoDicomBased
             }
             
             return toProcess;
+        }
+
+        private void RemovePatientNameEtc(DicomAnonymizer.SecurityProfile profile)
+        {
+            // we still want to remove PatientName, PatientAddress etc see these:
+            // https://dicom.nema.org/medical/dicom/2015c/output/chtml/part03/sect_C.2.3.html
+            profile.Add(new Regex("0010,.*"), SecurityProfileActions.Z);
         }
 
         private IEnumerable<DicomTag> GetDeleteTags()


### PR DESCRIPTION
DLS want the ability to extract structured reports without the brutal anonymisation of FoDicom 

This new feature is opt in on the FoDicomAnonymiser plugin.  When selected and the modality is SR then only the patient tags are cut `(0010, .*)` and everything else remains.

```csharp
  Dictionary<DicomTag, string> thingThatShouldDisappear = new Dictionary<DicomTag, string>
            {
                //Things we would want to disappear
                {DicomTag.PatientName,"Moscow"},
                {DicomTag.PatientBirthDate,"20010101"},
            };

            Dictionary<DicomTag, string> thingsThatShouldRemain = new Dictionary<DicomTag, string>
            {
                //Things we would want to remain
                {DicomTag.StudyDescription,"Frank has lots of problems, he lives at 60 Pancake road"},
                {DicomTag.SeriesDescription,"Coconuts"},
                {DicomTag.AlgorithmName,"Chessnuts"}, // would not normally be dropped by anonymisation
                {DicomTag.StudyDate,"20020101"},
            };
```