### PR TITLE
AddTag now supports passing multiple Catalogue at once

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile CT.it
       - name: Integration Tests
+        run: |
           cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:server=Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_ImageTable StudyDate null
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -46,7 +46,15 @@ jobs:
           cmd /c rdmpcli\rdmp.exe pack --file Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg
           cmd /c rdmpcli\rdmp.exe cmd listsupportedcommands
           cmd /c rdmpcli\rdmp.exe cmd describecommand CreateNewImagingDatasetSuite
-
+      - name: Get Imaging Template
+        run: |
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile CT.it
+      - name: Integration Tests
+          cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:server=Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_ImageTable StudyDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
       - name: Nuget push
         if: contains(github.ref,'refs/tags/')
         run: nuget push HIC.Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_KEY }} -SkipDuplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -55,9 +55,9 @@ jobs:
           cmd /c rdmpcli\rdmp.exe cmd NewObject ConnectionStringKeyword MicrosoftSqlServer Encrypt yes
           cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_ImageTable StudyDate null
-          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
-          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
-          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_*Table SeriesDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_*Table SeriesDate null
+          cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_*Table SeriesDate null
       - name: Nuget push
         if: contains(github.ref,'refs/tags/')
         run: nuget push HIC.Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_KEY }} -SkipDuplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -48,7 +48,7 @@ jobs:
           cmd /c rdmpcli\rdmp.exe cmd describecommand CreateNewImagingDatasetSuite
       - name: Get Imaging Template
         run: |
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile CT.it
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile D:\a\RdmpDicom\CT.it
       - name: Integration Tests
         run: |
           cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:server=Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -41,9 +41,12 @@ jobs:
           cd ../..
           nuget pack ./Rdmp.Dicom.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${{ steps.version.outputs.version }}
           nuget pack ./Rdmp.Dicom.Library.nuspec -Properties Configuration=Release -IncludeReferencedProjects -Symbols -Version ${{ steps.version.outputs.version }}
-          cmd /c rdmpcli\rdmp.exe pack --file Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg  --CatalogueConnectionString "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_Catalogue;TrustServerCertificate=true" --dataexportconnectionstring "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_DataExport;TrustServerCertificate=true"
-          cmd /c rdmpcli\rdmp.exe cmd listsupportedcommands  --CatalogueConnectionString "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_Catalogue;TrustServerCertificate=true" --dataexportconnectionstring "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_DataExport;TrustServerCertificate=true"
-          cmd /c rdmpcli\rdmp.exe cmd describecommand CreateNewImagingDatasetSuite --CatalogueConnectionString "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_Catalogue;TrustServerCertificate=true" --dataexportconnectionstring "Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_DataExport;TrustServerCertificate=true"
+          
+          cp Databases.Integration.yaml .\rdmpcli\Databases.yaml
+          cmd /c rdmpcli\rdmp.exe pack --file Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg
+          cmd /c rdmpcli\rdmp.exe cmd listsupportedcommands
+          cmd /c rdmpcli\rdmp.exe cmd describecommand CreateNewImagingDatasetSuite
+
       - name: Nuget push
         if: contains(github.ref,'refs/tags/')
         run: nuget push HIC.Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey ${{ secrets.NUGET_KEY }} -SkipDuplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -51,7 +51,7 @@ jobs:
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile D:\a\RdmpDicom\CT.it
       - name: Integration Tests
         run: |
-          cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:server=Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
+          cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_ImageTable StudyDate null
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -51,6 +51,8 @@ jobs:
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/HicServices/DicomTypeTranslation/main/Templates/CT.it -OutFile D:\a\RdmpDicom\CT.it
       - name: Integration Tests
         run: |
+          cmd /c rdmpcli\rdmp.exe cmd NewObject ConnectionStringKeyword MicrosoftSqlServer TrustServerCertificate yes
+          cmd /c rdmpcli\rdmp.exe cmd NewObject ConnectionStringKeyword MicrosoftSqlServer Encrypt yes
           cmd /c rdmpcli\rdmp.exe cmd CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest:Server=localhost;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ ../CT.it false false
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:CT_ImageTable StudyDate null
           cmd /c rdmpcli\rdmp.exe cmd AddTag Catalogue:*Table SeriesDate null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for running CLI `AddTag` command for multiple Catalogues at once
 
 ## [5.0.5] 2022-03-03
 

--- a/Databases.Integration.yaml
+++ b/Databases.Integration.yaml
@@ -1,0 +1,2 @@
+CatalogueConnectionString: Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_Catalogue;TrustServerCertificate=true
+DataExportConnectionString: Server=localhost;Integrated Security=true;Encrypt=yes;Database=TEST_DataExport;TrustServerCertificate=true

--- a/Rdmp.Dicom.Tests/Integration/ExecuteCommandAddTagTests.cs
+++ b/Rdmp.Dicom.Tests/Integration/ExecuteCommandAddTagTests.cs
@@ -77,9 +77,9 @@ namespace Rdmp.Dicom.Tests.Integration
             Assert.IsFalse(cmd.IsImpossible,cmd.ReasonCommandImpossible);
             cmd.Execute();
 
-            var ex = Assert.Throws<Exception>(()=>new ExecuteCommandAddTag(activator,catalogue,"StudyDate",null).Execute());
-            StringAssert.StartsWith("Failed check with message: There is already a column called 'StudyDate' in TableInfo ",ex.Message);
-
+            // attempting to add something that is already there is not a problem and just gets skipped
+            Assert.DoesNotThrow(()=>new ExecuteCommandAddTag(activator,catalogue,"StudyDate",null).Execute());
+            
             cmd = new ExecuteCommandAddTag(activator,catalogue,"SeriesDate",null);
             Assert.IsFalse(cmd.IsImpossible,cmd.ReasonCommandImpossible);
             cmd.Execute();

--- a/Rdmp.Dicom.sln
+++ b/Rdmp.Dicom.sln
@@ -1,11 +1,10 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29006.145
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{75983551-C46D-4645-8B06-F03ACA315A9D}"
 	ProjectSection(SolutionItems) = preProject
-		.travis.yml = .travis.yml
 		CHANGELOG.md = CHANGELOG.md
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		Packages.md = Packages.md

--- a/Rdmp.Dicom.sln
+++ b/Rdmp.Dicom.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{75983551-C46D-4645-8B06-F03ACA315A9D}"
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
+		Databases.Integration.yaml = Databases.Integration.yaml
 		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
 		Packages.md = Packages.md
 		rakeconfig.rb = rakeconfig.rb

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandAddTag.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandAddTag.cs
@@ -1,8 +1,10 @@
 ﻿using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Repositories.Construction;
 using Rdmp.Dicom.TagPromotionSchema;
 using ReusableLibraryCode.Checks;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Rdmp.Dicom.CommandExecution
@@ -12,69 +14,103 @@ namespace Rdmp.Dicom.CommandExecution
     /// </summary>
     public class ExecuteCommandAddTag : BasicCommandExecution
     {
-        private readonly TagColumnAdder _adder;
+        private readonly List<TagColumnAdder> _adders = new List<TagColumnAdder>();
 
-        public ExecuteCommandAddTag(BasicActivateItems activator,ICatalogue catalogue, 
+        /// <summary>
+        /// Add the given tag to the table under the <paramref name="catalogue"/>.
+        /// </summary>
+        /// <param name="activator">UI abstraction layer</param>
+        /// <param name="catalogue">The Catalogue you want to add the tag to.  Must have a single table under it.</param>
+        /// <param name="column">The name of a dicom tag</param>
+        /// <param name="dataType">Optional.  Pass null to lookup the dicom tags datatype automatically (recommended).  Pass a value to use an explicit SQL DBMS datatype instead.</param>
+        public ExecuteCommandAddTag(BasicActivateItems activator, ICatalogue catalogue,string column,string dataType) 
+            : this(activator,new[] { catalogue },column,dataType)
+        {
+
+        }
+
+        /// <summary>
+        /// Overload for use with the command line or for when adding the same column to multiple Catalogues
+        /// </summary>
+        /// <param name="activator">UI abstraction layer</param>
+        /// <param name="catalogue">The Catalogue you want to add the tag to.  Must have a single table under it.</param>
+        /// <param name="column">The name of a dicom tag</param>
+        /// <param name="dataType">Optional.  Pass null to lookup the dicom tags datatype automatically (recommended).  Pass a value to use an explicit SQL DBMS datatype instead.</param>
+        [UseWithObjectConstructor]
+        public ExecuteCommandAddTag(BasicActivateItems activator,ICatalogue[] catalogues, 
             [DemandsInitialization("Name of the new column you want created.")]
             string column, 
             [DemandsInitialization("Optional when column is the name of a Dicom Tag e.g. StudyInstanceUID")]
             string dataType):base(activator)
         {
+            foreach(var c in catalogues)
+            {
+                _adders.Add(BuildTagAdder(c,column, dataType));
+                
+                // once we can't process any Catalogue we should stop investigating
+                if (IsImpossible)
+                    break;
+            }
+        }
+
+        private TagColumnAdder BuildTagAdder(ICatalogue catalogue, string column, string dataType)
+        {
             var tables = catalogue.GetTableInfosIdeallyJustFromMainTables();
 
-            if(tables.Length != 1)
+            if (tables.Length != 1)
             {
                 SetImpossible($"There are {tables.Length} tables mapped under Catalogue {catalogue}");
-                return;
+                return null;
             }
 
-            if(string.IsNullOrWhiteSpace(column))
+            if (string.IsNullOrWhiteSpace(column))
             {
                 SetImpossible("Column name must be supplied");
-                return;
+                return null;
             }
-                
+
             var syntax = tables[0].GetQuerySyntaxHelper();
 
             //if user hasn't listed a specific datatype, guess it from the column 
-            if(string.IsNullOrWhiteSpace(dataType))
+            if (string.IsNullOrWhiteSpace(dataType))
             {
                 var available = TagColumnAdder.GetAvailableTags();
 
-                if(!available.Contains(column))
+                if (!available.Contains(column))
                 {
-                    var similar = available.Where(c=>c.Contains(column)).ToArray();
+                    var similar = available.Where(c => c.Contains(column)).ToArray();
 
-                    if(similar.Any())
+                    if (similar.Any())
                     {
                         SetImpossible(
                             $"Could not find a tag called '{column}'. Possibly  you meant:{Environment.NewLine}{string.Join(Environment.NewLine, similar)}");
-                        return;
+                        return null;
                     }
-                        
+
                     SetImpossible($"Could not find a tag called '{column}' or any like it");
-                    return;
+                    return null;
                 }
 
                 try
                 {
-                    dataType = TagColumnAdder.GetDataTypeForTag(column,syntax.TypeTranslater);
+                    dataType = TagColumnAdder.GetDataTypeForTag(column, syntax.TypeTranslater);
                 }
                 catch (Exception e)
                 {
-                    throw new("No dataType was specified and column name could not be resolved to a DicomTag",e);
+                    throw new("No dataType was specified and column name could not be resolved to a DicomTag", e);
                 }
-                
+
             }
-                        
-            _adder = new(column,dataType,(TableInfo)tables[0],new AcceptAllCheckNotifier());
-            
+
+            return new TagColumnAdder(column, dataType, (TableInfo)tables[0], new AcceptAllCheckNotifier());
         }
+
         public override void Execute()
         {
             base.Execute();
 
-            _adder.Execute();
+            foreach(var adder in _adders)
+                adder.Execute();
         }
     }
 }

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
@@ -122,6 +122,12 @@ namespace Rdmp.Dicom.CommandExecution
 
             List<DiscoveredTable> tablesCreated = new();
 
+            // create the database if it does not exist
+            if(!_databaseToCreateInto.Exists())
+            {
+                _databaseToCreateInto.Server.CreateDatabase(_databaseToCreateInto.GetRuntimeName());
+            }
+
             //Create with template?
             if(Template != null)
             {

--- a/Rdmp.Dicom/TagPromotionSchema/TagColumnAdder.cs
+++ b/Rdmp.Dicom/TagPromotionSchema/TagColumnAdder.cs
@@ -43,6 +43,9 @@ namespace Rdmp.Dicom.TagPromotionSchema
 
         public void Execute()
         {
+            if (ColumnAlreadyExists())
+                return;
+
             if(!SkipChecksAndSynchronization)
                 Check(_notifierForExecute);
 
@@ -70,10 +73,10 @@ namespace Rdmp.Dicom.TagPromotionSchema
             //synchronize the TableInfo
             new TableInfoSynchronizer(_tableInfo).Synchronize(notifier);
 
-            if (_tableInfo.ColumnInfos.Any(c => c.GetRuntimeName().Equals(_tagName)))
+            if(ColumnAlreadyExists())
             {
                 notifier.OnCheckPerformed(new(
-                    $"There is already a column called '{_tagName}' in TableInfo {_tableInfo}",CheckResult.Fail));
+                    $"There is already a column called '{_tagName}' in TableInfo {_tableInfo}.  No column will be created.",CheckResult.Warning));
                 return;
             }
 
@@ -87,6 +90,11 @@ namespace Rdmp.Dicom.TagPromotionSchema
             {
                 notifier.OnCheckPerformed(new($"Datatype '{_datatype}' is not supported",CheckResult.Fail, ex));
             }
+        }
+
+        private bool ColumnAlreadyExists()
+        {
+            return _tableInfo.ColumnInfos.Any(c => c.GetRuntimeName().Equals(_tagName));
         }
 
         private DiscoveredDatabase GetDatabase()


### PR DESCRIPTION
TODO : 

- [x] Integration tests in CI after creating the suite use the command to add to 1 table
- [x] Add a new tag to both at once
- [x] Add a tag that already exists in one/both (it should skip tags that are already on a table)