### PR TITLE
Task/rdmp-138 Error using PutDicomFilesInExtractionDirectories option in FoDicomAnonymiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix issue with PutDicomFilesInExtractionDirectories option in FoDicom Pipeline Component
+
 ## [7.0.1]
  - Documentation Update
  - Update to target RDMP version 8.1.0

--- a/Rdmp.Dicom/Extraction/FoDicomBased/DirectoryDecisions/PutDicomFilesInExtractionDirectories.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/DirectoryDecisions/PutDicomFilesInExtractionDirectories.cs
@@ -6,6 +6,10 @@ namespace Rdmp.Dicom.Extraction.FoDicomBased.DirectoryDecisions;
 
 public abstract class PutDicomFilesInExtractionDirectories : IPutDicomFilesInExtractionDirectories
 {
+
+
+    public PutDicomFilesInExtractionDirectories() : base() { }
+
     public string WriteOutDataset(DirectoryInfo outputDirectory, string releaseIdentifier, DicomDataset dicomDataset)
     {
         if(dicomDataset == null)


### PR DESCRIPTION
Using the `PutDicomFilesInExtractionDirectories` option causes extractions to crash, citing no empty constructor

Adding the empty constructor resolves this issue and allow the extraction to complete successfully