### PR TITLE
Bugfix/RDMP-144 Safer Handling of Dicom Opening

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -81,7 +81,7 @@ jobs:
           - AddTag Catalogue:CT_*Table SeriesDate null
           - AddTag Catalogue:CT_*Table SeriesDate null
           - AddTag Catalogue:CT_*Table SeriesDate null
-          - CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest2:Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ CT.it false true
+          # - CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest2:Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ CT.it false true
           EOC
       - name: Test
         run: |

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -81,7 +81,7 @@ jobs:
           - AddTag Catalogue:CT_*Table SeriesDate null
           - AddTag Catalogue:CT_*Table SeriesDate null
           - AddTag Catalogue:CT_*Table SeriesDate null
-          # - CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest2:Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ CT.it false true
+          - CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest2:Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ CT.it false true
           EOC
       - name: Test
         run: |

--- a/Packages.md
+++ b/Packages.md
@@ -11,3 +11,4 @@
 | ------- | ------------| ------- | ------- | -------------------------- |
 | HIC.DicomTypeTranslation | [GitHub](https://github.com/SMI/DicomTypeTranslation) | [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) | Translate dicom types into C# / database types | |
 | LibArchive.Net | [GitHub](https://github.com/jas88/libarchive.net) | [BSD] | Access archive formats without the LZMA bugs of SharpCompress | |
+| fo-dicom | [GitHub](https://github.com/fo-dicom/fo-dicom) | LICENCE GOES HERE | |"

--- a/Packages.md
+++ b/Packages.md
@@ -11,4 +11,4 @@
 | ------- | ------------| ------- | ------- | -------------------------- |
 | HIC.DicomTypeTranslation | [GitHub](https://github.com/SMI/DicomTypeTranslation) | [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) | Translate dicom types into C# / database types | |
 | LibArchive.Net | [GitHub](https://github.com/jas88/libarchive.net) | [BSD] | Access archive formats without the LZMA bugs of SharpCompress | |
-| fo-dicom | [GitHub](https://github.com/fo-dicom/fo-dicom) | LICENCE GOES HERE | |"
+| fo-dicom | [GitHub](https://github.com/fo-dicom/fo-dicom) | [MS-PL](https://github.com/fo-dicom/fo-dicom/blob/development/License.txt) | |"

--- a/Packages.md
+++ b/Packages.md
@@ -11,4 +11,3 @@
 | ------- | ------------| ------- | ------- | -------------------------- |
 | HIC.DicomTypeTranslation | [GitHub](https://github.com/SMI/DicomTypeTranslation) | [GPL 3.0](https://www.gnu.org/licenses/gpl-3.0.html) | Translate dicom types into C# / database types | |
 | LibArchive.Net | [GitHub](https://github.com/jas88/libarchive.net) | [BSD] | Access archive formats without the LZMA bugs of SharpCompress | |
-| [NUnit.Analyzers](https://nunit.org/) |[GitHub](https://github.com/nunit/nunit.analyzers) | [MIT](https://opensource.org/licenses/MIT) | Unit testing support code |

--- a/Rdmp.Dicom.Tests/PackageListIsCorrectTests.cs
+++ b/Rdmp.Dicom.Tests/PackageListIsCorrectTests.cs
@@ -108,7 +108,7 @@ internal sealed partial class PackageListIsCorrectTests
         return path;
     }
 
-    [GeneratedRegex("<PackageReference\\s+Include=\"(.*)\"\\s+Version=\"([^\"]*)\"", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex("<PackageReference\\s+Include=\"(.*)\"(\\s+Version=\"[^\"]*\")?", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex PackageRefRegex();
     [GeneratedRegex("^\\|\\s*\\[?([^ |\\]]+)(\\]\\([^)]+\\))?\\s*\\|", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex MarkdownEntryRegex();

--- a/Rdmp.Dicom.Tests/PackageListIsCorrectTests.cs
+++ b/Rdmp.Dicom.Tests/PackageListIsCorrectTests.cs
@@ -108,7 +108,7 @@ internal sealed partial class PackageListIsCorrectTests
         return path;
     }
 
-    [GeneratedRegex("<PackageReference\\s+Include=\"(.*)\"(\\s+Version=\"[^\"]*\")?", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    [GeneratedRegex("<PackageReference\\s+Include=\"([^\"]*)\"(\\s+Version=\"[^\"]*\")?", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex PackageRefRegex();
     [GeneratedRegex("^\\|\\s*\\[?([^ |\\]]+)(\\]\\([^)]+\\))?\\s*\\|", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex MarkdownEntryRegex();

--- a/Rdmp.Dicom.Tests/Rdmp.Dicom.Tests.csproj
+++ b/Rdmp.Dicom.Tests/Rdmp.Dicom.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Rdmp.Dicom.Tests</RootNamespace>
     <AssemblyName>Rdmp.Dicom.Tests</AssemblyName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/Rdmp.Dicom.UI/Rdmp.Dicom.UI.csproj
+++ b/Rdmp.Dicom.UI/Rdmp.Dicom.UI.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Rdmp.Dicom.UI</RootNamespace>
     <AssemblyName>Rdmp.Dicom.UI</AssemblyName>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Rdmp.Dicom/Attachers/Routing/AutoRoutingAttacher.cs
+++ b/Rdmp.Dicom/Attachers/Routing/AutoRoutingAttacher.cs
@@ -170,7 +170,7 @@ This Grouping will be used to extract the Modality code when deciding which tabl
     #region Process Results Of Pipeline Read
     public DataTable ProcessPipelineData(DataTable toProcess, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
     {
-        MySqlBulkCopy.BulkInsertBatchTimeoutInSeconds = int.MaxValue; //forever
+        //MySqlBulkCopy.BulkInsertBatchTimeoutInSeconds = int.MaxValue; //forever
 
         _sw.Start();
 

--- a/Rdmp.Dicom/Attachers/Routing/AutoRoutingAttacher.cs
+++ b/Rdmp.Dicom/Attachers/Routing/AutoRoutingAttacher.cs
@@ -170,7 +170,7 @@ This Grouping will be used to extract the Modality code when deciding which tabl
     #region Process Results Of Pipeline Read
     public DataTable ProcessPipelineData(DataTable toProcess, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
     {
-        //MySqlBulkCopy.BulkInsertBatchTimeoutInSeconds = int.MaxValue; //forever
+        MySqlBulkCopy.BulkInsertBatchTimeoutInSeconds = int.MaxValue; //forever
 
         _sw.Start();
 

--- a/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
+++ b/Rdmp.Dicom/Cache/Pipeline/PACSSource.cs
@@ -14,6 +14,7 @@ using Rdmp.Core.Curation;
 using System.Collections.Concurrent;
 using FellowOakDicom.Log;
 using FellowOakDicom.Network.Client;
+using Microsoft.Extensions.Logging;
 
 namespace Rdmp.Dicom.Cache.Pipeline;
 
@@ -90,7 +91,7 @@ public class PACSSource : SMICacheSource
         };
 
         //helps with tidying up resources if we abort or through an exception and neatly avoids ->  Access to disposed closure
-        using var server = new DicomServer<CachingSCP>(new DicomServerDependencies(new DesktopNetworkManager(),new ConsoleLogManager()));
+        using var server = new DicomServer<CachingSCP>(new DicomServerDependencies(new DesktopNetworkManager(), new LoggerFactory()));
         var client = DicomClientFactory.Create(dicomConfiguration.RemoteAetHost,
             dicomConfiguration.RemoteAetPort, false, dicomConfiguration.LocalAetTitle,
             dicomConfiguration.RemoteAetTitle);

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
@@ -114,7 +114,6 @@ public class ExecuteCommandCreateNewImagingDatasetSuite : BasicCommandExecution
 
     public override void Execute()
     {
-        if (1 == 1) return;
         var logging = LogManager.GetCurrentClassLogger();
 
         if (DicomSourceType == null)
@@ -128,7 +127,7 @@ public class ExecuteCommandCreateNewImagingDatasetSuite : BasicCommandExecution
         List<DiscoveredTable> tablesCreated = new();
 
         // create the database if it does not exist
-        if(!_databaseToCreateInto.Server.Exists() || !_databaseToCreateInto.Exists())
+        if(!_databaseToCreateInto.Server.Exists())// || !_databaseToCreateInto.Exists())
         {
             var create = _databaseToCreateInto.GetRuntimeName();
             logging.Info($"Creating '{create}'");

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
@@ -114,6 +114,7 @@ public class ExecuteCommandCreateNewImagingDatasetSuite : BasicCommandExecution
 
     public override void Execute()
     {
+        if (1 == 1) return;
         var logging = LogManager.GetCurrentClassLogger();
 
         if (DicomSourceType == null)

--- a/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
+++ b/Rdmp.Dicom/CommandExecution/ExecuteCommandCreateNewImagingDatasetSuite.cs
@@ -127,8 +127,7 @@ public class ExecuteCommandCreateNewImagingDatasetSuite : BasicCommandExecution
         List<DiscoveredTable> tablesCreated = new();
 
         // create the database if it does not exist
-        //if (!_databaseToCreateInto.Server.Exists() || !_databaseToCreateInto.Exists())
-        if (!_databaseToCreateInto.Exists())
+        if (!_databaseToCreateInto.Exists() || !_databaseToCreateInto.Server.Exists())
         {
             var create = _databaseToCreateInto.GetRuntimeName();
             logging.Info($"Creating '{create}'");

--- a/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
@@ -115,7 +115,7 @@ public partial class AmbiguousFilePath
                 {
                     listener?.OnNotify(this,
                      new NotifyEventArgs(ProgressEventType.Warning,
-                         $"Unable to find file {entry.Key}. You may wish to validate this"));
+                         $"Unable to find file '{entry.Key}'."));
                 }
                 continue;
             }

--- a/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
@@ -35,24 +35,22 @@ namespace Rdmp.Dicom.Extraction.FoDicomBased;
 /// </summary>
 public partial class AmbiguousFilePath
 {
-
     private readonly SortedDictionary<string, string> _fullPaths;
     private static readonly Regex RegexDigitsAndDotsOnly = DigitsAndDotsOnlyRegex();
 
 
-
-    public AmbiguousFilePath(string fullPath) : this(null,fullPath)
+    public AmbiguousFilePath(string fullPath) : this(null, fullPath)
     {
     }
 
-    public AmbiguousFilePath(string root, IEnumerable<(string,string)> paths)
+    public AmbiguousFilePath(string root, IEnumerable<(string, string)> paths)
     {
         //if root is provided but is not absolute
-        if(!string.IsNullOrWhiteSpace(root) && !IsAbsolute(root))
+        if (!string.IsNullOrWhiteSpace(root) && !IsAbsolute(root))
             throw new ArgumentException($"Specified root path '{root}' was not IsAbsolute", nameof(root));
 
         _fullPaths = new SortedDictionary<string, string>();
-        paths.Select(p => (Combine(root, p.Item1),p.Item2)).Each(p=>_fullPaths.Add(p.Item1,p.Item2));
+        paths.Select(p => (Combine(root, p.Item1), p.Item2)).Each(p => _fullPaths.Add(p.Item1, p.Item2));
     }
 
     public AmbiguousFilePath(string fullPath, string fileName)
@@ -65,7 +63,7 @@ public partial class AmbiguousFilePath
             {
                 _fullPaths = new SortedDictionary<string, string>();
                 using var zip = new LibArchiveReader(absPath);
-                zip.Entries().Each(e => _fullPaths.Add($"{absPath}!{e.Name}",$"{fileName}!{e.Name}"));
+                zip.Entries().Each(e => _fullPaths.Add($"{absPath}!{e.Name}", $"{fileName}!{e.Name}"));
                 return;
             }
         }
@@ -73,6 +71,7 @@ public partial class AmbiguousFilePath
         {
             // Not a zip so ignore, treat as single file
         }
+
         _fullPaths = new SortedDictionary<string, string> { { absPath, fileName } };
     }
 
@@ -82,7 +81,7 @@ public partial class AmbiguousFilePath
             return path;
 
         if (!IsZipReference(path))
-            return Path.Combine(root,path);
+            return Path.Combine(root, path);
 
         var bits = path.Split('!');
         return $"{Path.Combine(root, bits[0])}!{bits[1]}";
@@ -96,7 +95,7 @@ public partial class AmbiguousFilePath
     /// <param name="retryDelay">Number of milliseconds to wait after encountering an Exception reading before trying</param>
     /// <param name="listener"></param>
     /// <returns></returns>
-    public IEnumerable<ValueTuple<string,DicomFile>> GetDataset(int retryCount = 0, int retryDelay=100, IDataLoadEventListener listener = null)
+    public IEnumerable<ValueTuple<string, DicomFile>> GetDataset(int retryCount = 0, int retryDelay = 100, IDataLoadEventListener listener = null)
     {
         while (!_fullPaths.IsNullOrEmpty())
         {
@@ -106,17 +105,25 @@ public partial class AmbiguousFilePath
                 if (!IsDicomReference(entry.Key))
                     throw new AmbiguousFilePathResolutionException(
                         $"Path provided '{entry.Key}' was not to either an entry in a zip file or to a dicom file");
+
                 _fullPaths.Remove(entry.Key);
-                if (File.Exists(entry.Key))
+                DicomFile f = null;
+                try
                 {
-                    yield return new ValueTuple<string, DicomFile>(entry.Value, DicomFile.Open(entry.Key));
+                    f = DicomFile.Open(entry.Key);
                 }
-                else
+                catch (Exception e)
                 {
                     listener?.OnNotify(this,
-                     new NotifyEventArgs(ProgressEventType.Warning,
-                         $"Unable to find file '{entry.Key}'."));
+                        new NotifyEventArgs(ProgressEventType.Warning,
+                            $"Unable to find file '{entry.Key}'.", e));
                 }
+
+                if (f is not null)
+                {
+                    yield return new ValueTuple<string, DicomFile>(entry.Value, f);
+                }
+
                 continue;
             }
 
@@ -124,7 +131,7 @@ public partial class AmbiguousFilePath
             // Can't 'yield return' directly from inside try/catch, so buffer:
             List<(string tag, DicomFile)> resultQueue = new();
             var bits = entry.Key.Split('!');
-            TryAgain:
+        TryAgain:
             try
             {
                 var found = false;
@@ -140,16 +147,16 @@ public partial class AmbiguousFilePath
                         $"{bits[0]}!/{zipEntry.Name.Replace('/','\\')}",
                         $"{bits[0]}!\\{zipEntry.Name.Replace('/','\\')}",
                     };
-                    foreach(var name in tryNames)
-                        if (_fullPaths.TryGetValue(name,out var tag))
+                    foreach (var name in tryNames)
+                        if (_fullPaths.TryGetValue(name, out var tag))
                         {
                             if (name.Equals(entry.Key))
                                 found = true;
                             _fullPaths.Remove(name);
                             using var s = zipEntry.Stream;
                             var f = LoadStream(s);
-                            if (f!=null)
-                                resultQueue.Add((tag,f));
+                            if (f != null)
+                                resultQueue.Add((tag, f));
                         }
                 }
                 if (!found)
@@ -188,7 +195,7 @@ public partial class AmbiguousFilePath
 
     public static bool IsDicomReference(string fullPath)
     {
-        if(string.IsNullOrWhiteSpace(fullPath))
+        if (string.IsNullOrWhiteSpace(fullPath))
             return false;
 
         var extension = Path.GetExtension(fullPath);

--- a/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
@@ -116,7 +116,7 @@ public partial class AmbiguousFilePath
                 {
                     listener?.OnNotify(this,
                         new NotifyEventArgs(ProgressEventType.Warning,
-                            $"Unable to find file '{entry.Key}'.", e));
+                            $"Unable to read DICOM file '{entry.Key}'.", e));
                 }
 
                 if (f is not null)

--- a/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
+++ b/Rdmp.Dicom/Extraction/FoDicomBased/AmbiguousFilePath.cs
@@ -107,7 +107,16 @@ public partial class AmbiguousFilePath
                     throw new AmbiguousFilePathResolutionException(
                         $"Path provided '{entry.Key}' was not to either an entry in a zip file or to a dicom file");
                 _fullPaths.Remove(entry.Key);
-                yield return new ValueTuple<string,DicomFile>(entry.Value,DicomFile.Open(entry.Key));
+                if (File.Exists(entry.Key))
+                {
+                    yield return new ValueTuple<string, DicomFile>(entry.Value, DicomFile.Open(entry.Key));
+                }
+                else
+                {
+                    listener?.OnNotify(this,
+                     new NotifyEventArgs(ProgressEventType.Warning,
+                         $"Unable to find file {entry.Key}. You may wish to validate this"));
+                }
                 continue;
             }
 

--- a/Rdmp.Dicom/PipelineComponents/DicomSources/DicomSource.cs
+++ b/Rdmp.Dicom/PipelineComponents/DicomSources/DicomSource.cs
@@ -144,14 +144,14 @@ public abstract class DicomSource : IPluginDataFlowSource<DataTable>
                 case InvalidDataHandling.ThrowException:
 
                     //enforce types and leave any Exceptions uncaught
-                    value = DicomTypeTranslater.Flatten(DicomTypeTranslaterReader.GetCSharpValue(ds, item));
+                    value = DicomTypeTranslater.Flatten(new[] { DicomTypeTranslaterReader.GetCSharpValue(ds, item) });
                     break;
                 case InvalidDataHandling.MarkCorrupt:
 
                     try
                     {
                         //try to enforce types
-                        value = DicomTypeTranslater.Flatten(DicomTypeTranslaterReader.GetCSharpValue(ds, item));
+                        value = DicomTypeTranslater.Flatten(new[] { DicomTypeTranslaterReader.GetCSharpValue(ds, item) });
                     }
                     catch (Exception ex)
                     {
@@ -173,7 +173,7 @@ public abstract class DicomSource : IPluginDataFlowSource<DataTable>
                     //try to enforce types
                     try
                     {
-                        value = DicomTypeTranslater.Flatten(DicomTypeTranslaterReader.GetCSharpValue(ds, item));
+                        value = DicomTypeTranslater.Flatten(new[] { DicomTypeTranslaterReader.GetCSharpValue(ds, item) });
                     }
                     catch (Exception ex)
                     {

--- a/Rdmp.Dicom/Rdmp.Dicom.csproj
+++ b/Rdmp.Dicom/Rdmp.Dicom.csproj
@@ -26,7 +26,7 @@
 		<EmbeddedResource Include="db\up\005_EnsureUIDMapUnique.sql" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="HIC.DicomTypeTranslation" Version="4.0.3" />
+		<PackageReference Include="HIC.DicomTypeTranslation" Version="4.1.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Rdmp.Dicom/Rdmp.Dicom.csproj
+++ b/Rdmp.Dicom/Rdmp.Dicom.csproj
@@ -1,38 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <PackageId>HIC.Rdmp.Dicom</PackageId>
-    <RootNamespace>Rdmp.Dicom</RootNamespace>
-    <AssemblyName>Rdmp.Dicom</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="db\runAfterCreateDatabase\CreateSMIPluginDatabase.sql" />
-    <None Remove="db\up\001_AddIsExternalReferenceFlag.sql" />
-    <None Remove="db\up\002_ImagesToLoadList.sql" />
-    <None Remove="db\up\003_Quarantine.sql" />
-    <None Remove="db\up\004_TagPromotionConfiguration.sql" />
-    <None Remove="db\up\005_EnsureUIDMapUnique.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="db\runAfterCreateDatabase\CreateSMIPluginDatabase.sql" />
-    <EmbeddedResource Include="db\up\001_AddIsExternalReferenceFlag.sql" />
-    <EmbeddedResource Include="db\up\002_ImagesToLoadList.sql" />
-    <EmbeddedResource Include="db\up\003_Quarantine.sql" />
-    <EmbeddedResource Include="db\up\004_TagPromotionConfiguration.sql" />
-    <EmbeddedResource Include="db\up\005_EnsureUIDMapUnique.sql" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="HIC.DicomTypeTranslation" Version="4.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\RDMP\Rdmp.Core\Rdmp.Core.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<PackageId>HIC.Rdmp.Dicom</PackageId>
+		<RootNamespace>Rdmp.Dicom</RootNamespace>
+		<AssemblyName>Rdmp.Dicom</AssemblyName>
+		<TargetFramework>net8.0</TargetFramework>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="db\runAfterCreateDatabase\CreateSMIPluginDatabase.sql" />
+		<None Remove="db\up\001_AddIsExternalReferenceFlag.sql" />
+		<None Remove="db\up\002_ImagesToLoadList.sql" />
+		<None Remove="db\up\003_Quarantine.sql" />
+		<None Remove="db\up\004_TagPromotionConfiguration.sql" />
+		<None Remove="db\up\005_EnsureUIDMapUnique.sql" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="db\runAfterCreateDatabase\CreateSMIPluginDatabase.sql" />
+		<EmbeddedResource Include="db\up\001_AddIsExternalReferenceFlag.sql" />
+		<EmbeddedResource Include="db\up\002_ImagesToLoadList.sql" />
+		<EmbeddedResource Include="db\up\003_Quarantine.sql" />
+		<EmbeddedResource Include="db\up\004_TagPromotionConfiguration.sql" />
+		<EmbeddedResource Include="db\up\005_EnsureUIDMapUnique.sql" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="HIC.DicomTypeTranslation" Version="4.0.3" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="fo-dicom" Version="5.1.2" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\RDMP\Rdmp.Core\Rdmp.Core.csproj" />
+	</ItemGroup>
 </Project>

--- a/Rdmp.Dicom/Rdmp.Dicom.csproj
+++ b/Rdmp.Dicom/Rdmp.Dicom.csproj
@@ -3,7 +3,7 @@
     <PackageId>HIC.Rdmp.Dicom</PackageId>
     <RootNamespace>Rdmp.Dicom</RootNamespace>
     <AssemblyName>Rdmp.Dicom</AssemblyName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -7,12 +7,12 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyCompany("Health Informatics Centre, University of Dundee")]
 [assembly: AssemblyProduct("RDMP Dicom Plugin")]
-[assembly: AssemblyCopyright("Copyright (c) 2018 - 2020")]
+[assembly: AssemblyCopyright("Copyright (c) 2018 - 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // These should be replaced with correct values by the release process
-[assembly: AssemblyVersion("7.0.2")]
-[assembly: AssemblyFileVersion("7.0.2")]
-[assembly: AssemblyInformationalVersion("7.0.2")]
+[assembly: AssemblyVersion("7.0.3")]
+[assembly: AssemblyFileVersion("7.0.3")]
+[assembly: AssemblyInformationalVersion("7.0.3")]
 [assembly: InternalsVisibleTo("Rdmp.Dicom.Tests")]


### PR DESCRIPTION
User reported issue when using the FoDicomAnonymiser.
The Dicom file that was attempting to be processed did not exist on the file system.
RDMP throw an error and the extraction failed.

This fix checks that the file exists prior to attempting to open it, and warns the user if the file does not exist.