### PR TITLE
Reject when tests fails this time

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Package
         shell: bash
         run: |
+          dotnet test -c Release
           wget https://raw.githubusercontent.com/SMI/DicomTypeTranslation/main/Templates/CT.it
           dotnet publish Rdmp.Dicom/Rdmp.Dicom.csproj -o p/main -c Release --self-contained false -nologo
           dotnet publish Rdmp.Dicom.UI/Rdmp.Dicom.UI.csproj -o p/windows -c Release --self-contained false -nologo
@@ -68,7 +69,6 @@ jobs:
           rm -f p/main/fr-FR/Terminal.Gui.resources.dll
           rm -f p/main/pt-PT/Terminal.Gui.resources.dll
           7z a -tzip Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg plugin.nuspec p
-          7z a -tzip Rdmp.Dicom.${{ steps.version.outputs.version }}.rdmp plugin.nuspec p
           dotnet pack Rdmp.Dicom/Rdmp.Dicom.csproj -c Release -p:Version=${{ steps.version.outputs.version }} --include-source --include-symbols -o .
           cat > testcmd.yaml <<-EOC
           Commands:
@@ -85,13 +85,12 @@ jobs:
           - CreateNewImagingDatasetSuite "DatabaseType:MicrosoftSqlServer:Name:ImagingTest2:Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Encrypt=yes;TrustServerCertificate=true" ./data DicomFileCollectionSource CT_ CT.it false true
           EOC
       - name: Test
+        shell: bash
         run: |
-          dotnet test -c Release
           echo "Loading plugin"
           dotnet run --project RDMP\\Tools\\rdmp\\rdmp.csproj -c Release -- pack -p --file Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg --dir yaml
           7z t Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg
-            dotnet run --project RDMP\\Tools\\rdmp\\rdmp.csproj -c Release -- pack -p --file Rdmp.Dicom.${{ steps.version.outputs.version }}.rdmp --dir yaml
-          7z t Rdmp.Dicom.${{ steps.version.outputs.version }}.rdmp
+          cp Rdmp.Dicom.${{ steps.version.outputs.version }}.nupkg Rdmp.Dicom.${{ steps.version.outputs.version }}.rdmp
           echo "Running plugin test script"
           dotnet run --project RDMP\\Tools\\rdmp\\rdmp.csproj -c Release -- -f testcmd.yaml --dir yaml 
       - name: Store created nupkg files


### PR DESCRIPTION
Since the Github actions run on Windows under Powershell, the default is to ignore failures, which isn't really a very useful "test". This patch runs these steps under Bash instead, so failures actually fail the job, and adjusts the other steps to accommodate.