### PR TITLE
Update RDMP Reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.7] 2024-07-24
+
+- Update to target RDMP version 8.2.0
+
 ## [7.0.6] 2024-07-08
 
 - Updated to target RDMP version 8.2.0

--- a/Rdmp.Dicom/Rdmp.Dicom.csproj
+++ b/Rdmp.Dicom/Rdmp.Dicom.csproj
@@ -26,7 +26,7 @@
 		<EmbeddedResource Include="db\up\005_EnsureUIDMapUnique.sql" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="HIC.DicomTypeTranslation" Version="4.1.1" />
+		<PackageReference Include="HIC.DicomTypeTranslation" Version="4.1.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 
 // These should be replaced with correct values by the release process
-[assembly: AssemblyVersion("7.0.6")]
-[assembly: AssemblyFileVersion("7.0.6")]
-[assembly: AssemblyInformationalVersion("7.0.6")]
+[assembly: AssemblyVersion("7.0.7")]
+[assembly: AssemblyFileVersion("7.0.7")]
+[assembly: AssemblyInformationalVersion("7.0.7")]
 [assembly: InternalsVisibleTo("Rdmp.Dicom.Tests")]


### PR DESCRIPTION
Update the reference to RMDP to work with v8.2.1
Fixes the issue seen in https://github.com/HicServices/RDMP/issues/1898
Will release a new version of RDMPDICOM once this is merged