### PR TITLE
Fix CHANGELOG.md diff links, prep v7.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [7.1.2] 2024-10-28
+
+- Bump fo-dicom from 5.1.3 to 5.1.4
+- Bump HIC.DicomTypeTranslation from 4.1.3 to 4.1.5
+
 ## [7.1.1] 2024-10-16
 
 - Update to target RDMP v8.3.1
@@ -441,7 +448,9 @@ Updated to be compatible with RDMP 4.2
 
 - Initial commit from private repo
 
-[Unreleased]: https://github.com/SMI/RdmpDicom/compare/v7.1.0...develop
+[Unreleased]: https://github.com/SMI/RdmpDicom/compare/v7.1.2...develop
+[7.1.2]: https://github.com/SMI/RdmpDicom/compare/v7.1.1...v7.1.2
+[7.1.1]: https://github.com/SMI/RdmpDicom/compare/v7.1.0...v7.1.1
 [7.1.0]: https://github.com/SMI/RdmpDicom/compare/v7.0.8...v7.1.0
 [7.0.8]: https://github.com/SMI/RdmpDicom/compare/v7.0.7...v7.0.8
 [7.0.7]: https://github.com/SMI/RdmpDicom/compare/v7.0.6...v7.0.7

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 
 // These should be replaced with correct values by the release process
-[assembly: AssemblyVersion("7.1.1")]
-[assembly: AssemblyFileVersion("7.1.1")]
-[assembly: AssemblyInformationalVersion("7.1.1")]
+[assembly: AssemblyVersion("7.1.2")]
+[assembly: AssemblyFileVersion("7.1.2")]
+[assembly: AssemblyInformationalVersion("7.1.2")]
 [assembly: InternalsVisibleTo("Rdmp.Dicom.Tests")]


### PR DESCRIPTION
(Just version bumps in RdmpDicom, but unblocks Mongo update in SMI)